### PR TITLE
Add server db create script

### DIFF
--- a/server/src/createServerTables.sql
+++ b/server/src/createServerTables.sql
@@ -33,40 +33,44 @@
 START TRANSACTION;
 
 
-CREATE TABLE User
+CREATE TABLE ArcUser
 (
-   UID VARCHAR(60) PRIMARY KEY CHECK(LENGTH((TRIM(UID)) = 60)),
+   UID VARCHAR(60) PRIMARY KEY CHECK(CHAR_LENGTH(TRIM(UID)) = 60),
    FirstName VARCHAR(60) NOT NULL, 
    LastName VARCHAR(60) NOT NULL,
    Email VARCHAR(319) CHECK(TRIM(Email) LIKE '_%@_%._%')
 );
 
---enforce case-insensitive uniqueness of user e-mail addresses
+--Enforce case-insensitive uniqueness of user e-mail addresses
 CREATE UNIQUE INDEX idx_Unique_InstructorEmail
-ON User(LOWER(TRIM(Email)));
+ON ArcUser(LOWER(TRIM(Email)));
 
-
+--Define a table to store an Arc
+-- Primary Key: UID is the ID of the user that created the arc
 CREATE TABLE Arc
 (
-   UID VARCHAR(60) NOT NULL CHECK(LENGTH((TRIM(UID)) = 60)),
-   AID VARCHAR(60) NOT NULL CHECK(LENGTH((TRIM(AID)) = 60)),
+   UID VARCHAR(60) NOT NULL CHECK(CHAR_LENGTH(TRIM(UID)) = 60) REFERENCES ArcUser,
+   AID VARCHAR(60) NOT NULL CHECK(CHAR_LENGTH(TRIM(AID)) = 60),
    Title VARCHAR(60) NOT NULL,
    Description Text, 
    ParentArc VARCHAR(63) , 
-   FOREIGN KEY UID REFERENCES User.UID, 
-   PRIMARY KEY (UID AID)
+   PRIMARY KEY (UID, AID)
 );
 
-
+--Define a table to store a task
+-- Primary Key: AID and TID
+-- AID is the ID of the Arc the task belongs to
+-- TID is the ID of the task within this table 
 CREATE TABLE Task
 (
-   AID VARCHAR(60) NOT NULL CHECK(LENGTH((TRIM(AID)) = 60)),
-   TID VARCHAR(60) NOT NULL CHECK(LENGTH((TRIM(TID)) = 60)),
-   Title VARCHAR(60) NOT NULL CHECK(LENGTH((TRIM(Title)) > 0))
+   AID VARCHAR(60) NOT NULL CHECK(CHAR_LENGTH(TRIM(AID)) = 60),
+   UID VARCHAR(60) NOT NULL CHECK(CHAR_LENGTH(TRIM(UID)) = 60),
+   TID VARCHAR(60) NOT NULL CHECK(CHAR_LENGTH(TRIM(TID)) = 60),
+   Title VARCHAR(60) NOT NULL CHECK(CHAR_LENGTH(TRIM(Title)) > 0),
    Description TEXT, 
    DueDate TIMESTAMP,
    Location VARCHAR(256), 
-   FOREIGN KEY AID REFERENCES Arc.AID, 
+   FOREIGN KEY (AID, UID) REFERENCES Arc,
    PRIMARY Key (AID, TID)
 );
 

--- a/server/src/createServerTables.sql
+++ b/server/src/createServerTables.sql
@@ -1,0 +1,82 @@
+--createTables.sql - ArcPlanner
+
+--Matthew Chastain, Justin Grabowski, Kevin Kelly, Jonathan Middleton
+-- CS298 Spring 2019 Team CGKM
+
+--Version 1
+
+--*Add licence*
+
+--PROVIDED AS IS. NO WARRANTIES EXPRESSED OR IMPLIED. USE AT YOUR OWN RISK.
+
+--This script creates schema, tables, and indexes for the arcPlanner application
+
+--E-mail address management is based on the discussion presented at:
+-- https://gist.github.com/smurthys/feba310d8cc89c4e05bdb797ca0c6cac
+
+
+--The results of running this script will be spooled to 
+-- 'spoolCreateTables.txt'
+
+\o 'spoolCreateTables.txt'
+
+--Output script execution data
+\qecho -n 'Script run on '
+\qecho -n `date /t`
+\qecho -n 'at '
+\qecho `time /t`
+\qecho -n 'Script run by ' :USER ' on server ' :HOST ' with db ' :DBNAME
+\qecho ' '
+\qecho
+
+
+START TRANSACTION;
+
+
+CREATE TABLE User
+(
+   UID VARCHAR(60) PRIMARY KEY CHECK(LENGTH((TRIM(UID)) = 60)),
+   FirstName VARCHAR(60) NOT NULL, 
+   LastName VARCHAR(60) NOT NULL,
+   Email VARCHAR(319) CHECK(TRIM(Email) LIKE '_%@_%._%')
+);
+
+--enforce case-insensitive uniqueness of user e-mail addresses
+CREATE UNIQUE INDEX idx_Unique_InstructorEmail
+ON User(LOWER(TRIM(Email)));
+
+
+CREATE TABLE Arc
+(
+   UID VARCHAR(60) NOT NULL CHECK(LENGTH((TRIM(UID)) = 60)),
+   AID VARCHAR(60) NOT NULL CHECK(LENGTH((TRIM(AID)) = 60)),
+   Title VARCHAR(60) NOT NULL,
+   Description Text, 
+   ParentArc VARCHAR(63) , 
+   FOREIGN KEY UID REFERENCES User.UID, 
+   PRIMARY KEY (UID AID)
+);
+
+
+CREATE TABLE Task
+(
+   AID VARCHAR(60) NOT NULL CHECK(LENGTH((TRIM(AID)) = 60)),
+   TID VARCHAR(60) NOT NULL CHECK(LENGTH((TRIM(TID)) = 60)),
+   Title VARCHAR(60) NOT NULL CHECK(LENGTH((TRIM(Title)) > 0))
+   Description TEXT, 
+   DueDate TIMESTAMP,
+   Location VARCHAR(256), 
+   FOREIGN KEY AID REFERENCES Arc.AID, 
+   PRIMARY Key (AID, TID)
+);
+
+
+COMMIT;
+
+
+\qecho ' '
+\qecho ----------------------------
+\qecho End of script
+
+-- Turn off spooling
+\o

--- a/server/src/createServerTables.sql
+++ b/server/src/createServerTables.sql
@@ -46,7 +46,9 @@ CREATE UNIQUE INDEX idx_Unique_InstructorEmail
 ON ArcUser(LOWER(TRIM(Email)));
 
 --Define a table to store an Arc
--- Primary Key: UID is the ID of the user that created the arc
+-- Primary Key: (UID, AID)
+-- UID is the ID of the user that created the arc
+-- AID is the ID of the Arc within the table
 CREATE TABLE Arc
 (
    UID VARCHAR(60) NOT NULL CHECK(CHAR_LENGTH(TRIM(UID)) = 60) REFERENCES ArcUser,
@@ -60,7 +62,7 @@ CREATE TABLE Arc
 --Define a table to store a task
 -- Primary Key: AID and TID
 -- AID is the ID of the Arc the task belongs to
--- TID is the ID of the task within this table 
+-- TID is the ID of the Task within this table 
 CREATE TABLE Task
 (
    AID VARCHAR(60) NOT NULL CHECK(CHAR_LENGTH(TRIM(AID)) = 60),

--- a/server/src/createServerTables.sql
+++ b/server/src/createServerTables.sql
@@ -33,6 +33,9 @@
 START TRANSACTION;
 
 
+--Define a table to store an ArcUser
+-- Primary Key: UID
+-- UID is the ID of the user within the table
 CREATE TABLE ArcUser
 (
    UID VARCHAR(60) PRIMARY KEY CHECK(CHAR_LENGTH(TRIM(UID)) = 60),
@@ -46,34 +49,28 @@ CREATE UNIQUE INDEX idx_Unique_InstructorEmail
 ON ArcUser(LOWER(TRIM(Email)));
 
 --Define a table to store an Arc
--- Primary Key: (UID, AID)
--- UID is the ID of the user that created the arc
+-- Primary Key: AID
 -- AID is the ID of the Arc within the table
 CREATE TABLE Arc
 (
-   UID VARCHAR(60) NOT NULL CHECK(CHAR_LENGTH(TRIM(UID)) = 60) REFERENCES ArcUser,
-   AID VARCHAR(60) NOT NULL CHECK(CHAR_LENGTH(TRIM(AID)) = 60),
+   AID VARCHAR(60) NOT NULL PRIMARY KEY CHECK(CHAR_LENGTH(TRIM(AID)) = 60),
+   UID VARCHAR(60) NOT NULL REFERENCES ArcUser,
    Title VARCHAR(60) NOT NULL,
    Description Text, 
-   ParentArc VARCHAR(63) , 
-   PRIMARY KEY (UID, AID)
+   ParentArc VARCHAR(63)
 );
 
 --Define a table to store a task
--- Primary Key: AID and TID
--- AID is the ID of the Arc the task belongs to
+-- Primary Key:TID
 -- TID is the ID of the Task within this table 
 CREATE TABLE Task
 (
-   AID VARCHAR(60) NOT NULL CHECK(CHAR_LENGTH(TRIM(AID)) = 60),
-   UID VARCHAR(60) NOT NULL CHECK(CHAR_LENGTH(TRIM(UID)) = 60),
-   TID VARCHAR(60) NOT NULL CHECK(CHAR_LENGTH(TRIM(TID)) = 60),
+   TID VARCHAR(60) NOT NULL PRIMARY KEY CHECK(CHAR_LENGTH(TRIM(TID)) = 60),
+   AID VARCHAR(60) NOT NULL REFERENCES Arc,
    Title VARCHAR(60) NOT NULL CHECK(CHAR_LENGTH(TRIM(Title)) > 0),
    Description TEXT, 
    DueDate TIMESTAMP,
-   Location VARCHAR(256), 
-   FOREIGN KEY (AID, UID) REFERENCES Arc,
-   PRIMARY Key (AID, TID)
+   Location VARCHAR(256)
 );
 
 


### PR DESCRIPTION
Add a script `createServerTables` to create the db tables within a Postgres server
This file is for use in our future server implementation and is not intended to be used with SQL Lite
This PR closes #8 