### PR TITLE
fixed logical schema error with primary key

### DIFF
--- a/docs/Logical-Schema-and-Table-Summaries.md
+++ b/docs/Logical-Schema-and-Table-Summaries.md
@@ -1,14 +1,14 @@
-The below is a the logical schema with the associated table summaries
+The below is a the logical schema with the associated table summaries. Bold represents Primary keys.
 
 ## Logical Schema
 
-User ( UID, First Name*, Last Name*, Email Address )
+User ( **UID**, First Name*, Last Name*, Email Address )
 
-Arc ( UID, AID, Title*, Description, Parent Arc )  
+Arc ( **AID**, UID,  Title*, Description, Parent Arc )  
 _UID references User.UID_  
 _Parent Arc references Arc.AID_
 
-Task ( AID, TID, Title*, Description, Due Date, Location )  
+Task ( **TID**, AID, Title*, Description, Due Date, Location )  
 _AID references Arc.AID_
 
 ## **Table User** 
@@ -37,7 +37,7 @@ This table stores the details of Arcs. The table and its attributes have a one-t
 | --- | --- |
 | **Table** | Arc |
 | **ER Origin** | Entity Arc |
-| **Primary Key** | UID, AID |
+| **Primary Key** | AID |
 | **Foreign Keys** | Parent Arc |
 | **Uniqueness Constraint** | None |
 
@@ -56,7 +56,7 @@ This table stores the details of tasks. The table and its attributes have a one-
 | --- | --- |
 | **Table** | Task |
 | **ER Origin** | Entity Task |
-| **Primary Key** | AID, TID |
+| **Primary Key** | TID |
 | **Foreign Keys** | None |
 | **Uniqueness Constraint** | None |
 

--- a/docs/Normalization-and-Optimization-of-Schema.md
+++ b/docs/Normalization-and-Optimization-of-Schema.md
@@ -3,15 +3,15 @@
 | UID | AID | Title | Description | Parent Arc |
 | --- | --- | --- | --- | --- |
 
-**Candidate Keys:** UID is the only candidate key because AID is a FK and the remaining attributes or any combination of AID with the remaining attributes do not guarantee uniqueness.
+**Candidate Keys:** AID is the only candidate key because UID is a FK and the remaining attributes or any combination of AID with the remaining attributes do not guarantee uniqueness.
 
 ### Functional Dependencies:
 
-(UID, AID) -> Tile
+AID -> Tile
 
-(UID, AID) -> Description
+AID -> Description
 
-(UID, AID) -> Parent Arc
+AID -> Parent Arc
 
 **1NF:** Arc is already in first normal form because there are no composite attributes in this table and all non-key attributes depend on a key-attribute.
 
@@ -26,23 +26,23 @@
 | AID | TID | Title | Description | Due Date | Location |
 | --- | --- | --- | --- | --- | --- |
 
-**Candidate Keys:** The combination of AID and TID is the only candidate key.
+**Candidate Keys:** TID is the only candidate key.
 
 ### Functional Dependencies:
 
-(AID, TID) -> Title
+TID -> Title
 
-(AID, TID) -> Description
+TID -> Description
 
-(AID, TID) -> Due Date
+TID -> Due Date
 
-(AID, TID) -> Location
+TID -> Location
 
 **1NF:** Task is in first normal form because there are no composite attributes in this table and all non-key attributes depend on a key-attribute.
 
 **2NF:** There are no partial dependencies because all non-key attributes depend on whole candidate-keys, therefore the Task table is in second normal form.
 
-**3NF:** There are no transitive dependencies because there are no non-key attributes that depend on something other than a candidate key. Title, Description, DueDate, and Location all depend upon the combination of the AID and TID. Therefore, the Task table is in third normal form.
+**3NF:** There are no transitive dependencies because there are no non-key attributes that depend on something other than a candidate key. AID, Title, Description, DueDate, and Location all depend upon TID. Therefore, the Task table is in third normal form.
 
 **BCNF:** There are no key-attribute dependencies because all key attributes do not depend on anything other than a candidate key. Therefore, the Task table is in Boyce-Codd normal form.
 


### PR DESCRIPTION
This PR addresses the issue found in PR #11 and documented in issue #19.

The composite primary keys in both `Arc` and `Task` were corrected to be now broken up so the foreign key did was not part of the primary key. The logical schema summary fix required me to also update the normalized/optimized schema as well.

These changes are already made in the wiki, this PR just moves those changes to the Docs Folder and also allows review of those changes.

closes #19 