### PR TITLE
Add add/remove Sub arc functions

### DIFF
--- a/client/src/arcplanner/lib/model/arc.dart
+++ b/client/src/arcplanner/lib/model/arc.dart
@@ -16,9 +16,10 @@ class Arc {
   String _description;
   String _parentArc;
   List<Task> tasks;
+  List<Arc> subArcs;
 
   // Constructor
-  Arc(this._uid, this._title, {description = null, parentArc = null}) { 
+  Arc(this._uid, this._title, {description = null, parentArc = null}) {
     this._aid = new Uuid().v4();
     this._description = description;
     this._parentArc = parentArc;
@@ -107,11 +108,9 @@ class Arc {
   }
 
   /*   
-  * Given a taskID it deletes the task entry for the supplied task ID. It then 
-  *  searches the collection of task objects in the instance of Arc until it finds
-  *  the correct task. It then removes and deletes that task from the arc object. 
-  *  The deletion of the class will call the destructor function of the Task 
-  *  object
+  * Description: Given a taskID it deletes the task entry for the supplied task ID. 
+  *  It then searches the collection of task objects in the instance of Arc until it 
+  *  finds the correct task. It then removes and deletes that task from the arc object. 
   * @param taskID the TID of the task that needs to be deleted 
   */
   void removeTask(String taskID) {
@@ -127,5 +126,46 @@ class Arc {
       print(e);
       return null;
     }
+  }
+
+  /*
+  * Description: Adds the given subArc to the collection of subArcs that the Arc class has.
+  * @param subArc is the Arc to be added to the parent's collection of subarcs
+  */
+  void addSubArc(Arc subArc) {
+    subArcs.add(subArc);
+  }
+
+  /*
+  * Description: Given the ID of the sub arc the correct Arc is found in the SQLite file 
+  *  and deleted. It is then also found in the arc instance's collection of sub arcs. 
+  *  Once found that arc runs its own destructor function.
+  * @param subArcID is the ID that represents the subArc that is going to removed.
+  */
+  void removeSubArc(String subArcID) {
+    var db = new DatabaseHelper();
+
+    subArcs.firstWhere((subArc) => subArc.aid == subArcID).removeAll();
+
+    db.deleteArc(subArcID);
+    subArcs.removeWhere((subArc) => subArc.aid == subArcID);
+  }
+
+  /*
+  * Description: Removes all tasks and subArcs that belong to the Arc
+  */
+  void removeAll() {
+    var db = new DatabaseHelper();
+
+    // Delete all tasks in database then all objects
+    tasks.forEach((task) => db.deleteTask(task.tid));
+    tasks.clear();
+
+    // Call remove all function on each subArc
+    subArcs.forEach((subArc) {
+      subArc.removeAll();
+      db.deleteArc(subArc.aid);
+    });
+    subArcs.clear(); 
   }
 }

--- a/client/src/arcplanner/lib/util/databaseHelper.dart
+++ b/client/src/arcplanner/lib/util/databaseHelper.dart
@@ -164,7 +164,7 @@ class DatabaseHelper {
   }
 
   // Deletes a arc with the given ID
-  Future<int> deleteArc(int id) async {
+  Future<int> deleteArc(String id) async {
     var dbClient = await db;
     int result = await dbClient
         .delete(_arcTable, where: "$_arcAID = ?", whereArgs: [id]);


### PR DESCRIPTION
This PR adds the `addSubArc` and `removeSubArc` functions to the class Arc. 

The `addSubArc` function is given an Arc already which assumes there is a function within the app that creates an arc then determines that it is a subArc of a specific arc and uses `addSubArc` to add it to that arc. It also assumes that function already set the SQLite field `parentArc` to the correct value. This may have to change in the future but for now this is a good placeholder until that general add Arc function is created.

I had to add a function `removeAll` which removes all tasks and sub arcs from the arc. This is used in `removeSubArc` function to ensure that all tasks and arcs belonging to the subarc to be deleted are also deleted as well. With this in mind we should ensure that when a user wants to delete a subarc we supply an error message along the lines of "This will delete all arcs and tasks belonging to this sub arc. Are you sure you want to do this?"

One possible extension to this is to ask user if they want to move all connected tasks/subarcs to another arc.

fixes #23 