### PR TITLE
Add "completed" attribute to DB entities

### DIFF
--- a/client/src/arcplanner/lib/model/arc.dart
+++ b/client/src/arcplanner/lib/model/arc.dart
@@ -4,8 +4,8 @@
  * Provided AS IS. No warranties expressed or implied. Use at your own risk.
  */
 
-import './../model/task.dart';
-import './../util/databaseHelper.dart';
+import 'package:arcplanner/model/task.dart';
+import 'package:arcplanner/util/databaseHelper.dart';
 import 'package:uuid/uuid.dart';
 
 class Arc {
@@ -15,6 +15,7 @@ class Arc {
   String _title;
   String _description;
   String _parentArc;
+  bool _completed;
   List<Task> tasks;
   List<Arc> subArcs;
 
@@ -23,6 +24,7 @@ class Arc {
     this._aid = new Uuid().v4();
     this._description = description;
     this._parentArc = parentArc;
+    this._completed = false;
   }
 
   // Defines a user map.  Helps with moving info betwen the db
@@ -33,6 +35,7 @@ class Arc {
     _title = obj["title"];
     _description = obj["description"];
     _parentArc = obj["parentarc"];
+    _completed = obj["completed"];
   }
 
   // Getters
@@ -41,6 +44,7 @@ class Arc {
   String get title => _title;
   String get description => _description;
   String get parentArc => _parentArc;
+  bool get completed => _completed;
 
   // Puts object data onto a user map
   Map<String, dynamic> toMap() {
@@ -49,6 +53,7 @@ class Arc {
     map["title"] = _title;
     map["description"] = _description;
     map["parentarc"] = _parentArc;
+    map["completd"] =_completed;
 
     if (aid != null) {
       map["aid"] = _aid;
@@ -63,6 +68,7 @@ class Arc {
     _title = map["title"];
     _description = map["description"];
     _parentArc = map["parentarc"];
+    _completed = map["completed"];
   }
 
 /*---------------Member Functions-------------*/

--- a/client/src/arcplanner/lib/model/arc.dart
+++ b/client/src/arcplanner/lib/model/arc.dart
@@ -53,7 +53,7 @@ class Arc {
     map["title"] = _title;
     map["description"] = _description;
     map["parentarc"] = _parentArc;
-    map["completd"] =_completed;
+    map["completed"] =_completed;
 
     if (aid != null) {
       map["aid"] = _aid;

--- a/client/src/arcplanner/lib/model/task.dart
+++ b/client/src/arcplanner/lib/model/task.dart
@@ -14,6 +14,7 @@ class Task {
   String _description;
   String _dueDate; // SQLite will store the dueDate as TEXT type
   String _location;
+  bool _completed;
 
   // Constructor
   Task(this._aid, this._title,
@@ -22,6 +23,7 @@ class Task {
     this._description = description;
     this._dueDate = dueDate;
     this._location = location;
+    this._completed = false;
   }
 
   // Defines a user map.  Helps with moving info betwen the db
@@ -33,6 +35,7 @@ class Task {
     _description = obj["description"];
     _dueDate = obj["duedate"];
     _location = obj["location"];
+    _completed = obj["completed"];
   }
 
   // Getters
@@ -42,6 +45,7 @@ class Task {
   String get description => _description;
   String get duedate => _dueDate;
   String get location => _location;
+  bool get completed => _completed;
 
   // Puts object data onto a user map
   Map<String, dynamic> toMap() {
@@ -51,6 +55,7 @@ class Task {
     map["description"] = _description;
     map["duedate"] = _dueDate;
     map["location"] = _location;
+    map["completed"] = _completed;
 
     if (tid != null) {
       map["tid"] = _tid;
@@ -66,5 +71,6 @@ class Task {
     _description = map["description"];
     _dueDate = map["duedate"];
     _location = map["location"];
+    _completed = map["completed"];
   }
 }

--- a/client/src/arcplanner/lib/util/databaseHelper.dart
+++ b/client/src/arcplanner/lib/util/databaseHelper.dart
@@ -9,9 +9,9 @@ import 'package:path_provider/path_provider.dart';
 import 'package:path/path.dart';
 import 'package:sqflite/sqflite.dart';
 import 'dart:async';
-import './../model/user.dart';
-import './../model/task.dart';
-import './../model/arc.dart';
+import 'package:arcplanner/model/user.dart';
+import 'package:arcplanner/model/task.dart';
+import 'package:arcplanner/model/arc.dart';
 
 class DatabaseHelper {
   static final DatabaseHelper _instance = new DatabaseHelper.internal();
@@ -38,6 +38,7 @@ class DatabaseHelper {
   static final String _arcTitle = "Title";
   static final String _arcDesc = "Description";
   static final String _arcPArc = "ParentArc";
+  static final int _arcCompleted = 0;
 
   static final String _taskTable = "Task";
   static final String _taskAID = "AID";
@@ -46,6 +47,8 @@ class DatabaseHelper {
   static final String _taskDesc = "Description";
   static final String _taskDueDate = "DueDate";
   static final String _taskLoc = "Location";
+  static final int _taskCompleted = 0;
+
 
 // Singleton database initialization
   Future<Database> get db async{
@@ -80,7 +83,8 @@ class DatabaseHelper {
           $_arcAID TEXT PRIMARY KEY NOT NULL CHECK(LENGTH($_arcAID) <= $_uuidSize), 
           $_arcTitle TEXT NOT NULL CHECK(LENGTH($_arcTitle) <= $_nameSize), 
           $_arcDesc TEXT, 
-          $_arcPArc TEXT CHECK(LENGTH($_arcPArc) = $_uuidSize)
+          $_arcPArc TEXT CHECK(LENGTH($_arcPArc) = $_uuidSize),
+          $_arcCompleted INTEGER CHECK($_arcCompleted == 0 OR $_arcCompleted == 1)
           )""");
     await db.execute("""
         CREATE TABLE $_taskTable(
@@ -89,7 +93,8 @@ class DatabaseHelper {
           $_taskTitle TEXT CHECK(LENGTH($_taskTitle) <= $_nameSize), 
           $_taskDesc TEXT, 
           $_taskDueDate TEXT, 
-          $_taskLoc TEXT CHECK(LENGTH($_taskLoc) <= $_locSize)
+          $_taskLoc TEXT CHECK(LENGTH($_taskLoc) <= $_locSize),
+          $_taskCompleted INTEGER CHECK($_taskCompleted == 0 OR $_taskCompleted == 1)
           )""");
     print("Tables created");
   }

--- a/client/src/arcplanner/lib/util/databaseHelper.dart
+++ b/client/src/arcplanner/lib/util/databaseHelper.dart
@@ -38,7 +38,7 @@ class DatabaseHelper {
   static final String _arcTitle = "Title";
   static final String _arcDesc = "Description";
   static final String _arcPArc = "ParentArc";
-  static final int _arcCompleted = 0;
+  static final String _arcCompleted = "Completed";
 
   static final String _taskTable = "Task";
   static final String _taskAID = "AID";
@@ -47,7 +47,7 @@ class DatabaseHelper {
   static final String _taskDesc = "Description";
   static final String _taskDueDate = "DueDate";
   static final String _taskLoc = "Location";
-  static final int _taskCompleted = 0;
+  static final String _taskCompleted = "Completed";
 
 
 // Singleton database initialization

--- a/docs/Basic-DB-test.md
+++ b/docs/Basic-DB-test.md
@@ -5,7 +5,6 @@ import 'package:arcplanner/model/arc.dart';
 import 'package:arcplanner/model/task.dart';
 import 'package:arcplanner/model/user.dart';
 import 'package:arcplanner/util/databaseHelper.dart';
-import 'package:flutter/material.dart';
 
 void main () async {
 
@@ -13,8 +12,8 @@ void main () async {
 
   //add user, arc, task
   User sally = new User("sally", "seashells", "this@that.com");
-  Arc getOrganized = new Arc("1", "1","clean house","",null);
-  Task cleanOffice = new Task("1", "1","clean office","papers and stuff","tomorrow","home");
+  Arc getOrganized = new Arc( sally.uid,"clean house");
+  Task cleanOffice = new Task(getOrganized.aid, "clean office");
   await db.insertUser(sally);
   await db.insertArc(getOrganized);
   await db.insertTask(cleanOffice);
@@ -25,17 +24,32 @@ void main () async {
   int count2 = await db.getArcCount();
   int count3 = await db.getTaskCount();
 
-  print("Users: $count1");
-  print("Arcs: $count2");
-  print("Tasks: $count3");
+  print("Database insert/read test");
+  if(count1 == 1) print("User: Pass");
+  else print("User: Fail");
+  if(count2 == 1) print("Arc:  Pass");
+  else print("Arc:  Fail");
+  if(count3 == 1) print("Task: Pass");
+  else print("Task: Fail");
 
-  // await db.deleteTask(1);
-  // await db.deleteArc(1);
+  await db.deleteTask(cleanOffice.tid);
+  await db.deleteArc(getOrganized.aid);
+  await db.deleteUser(sally.uid);
+
+  count1 = await db.getUserCount();
+  count2 = await db.getArcCount();
+  count3 = await db.getTaskCount();
+
+  print("Database delete test");
+
+  if(count1 == 0) print("User: Pass");
+  else print("User: Fail");
+  if(count2 == 0) print("Arc:  Pass");
+  else print("Arc:  Fail");
+  if(count3 == 0) print("Task: Pass");
+  else print("Task: Fail");
+
   db.close();
-
-  runApp(MyApp());
 }
-// default main commented out for test
-//void main() => runApp(MyApp());
 ```
 


### PR DESCRIPTION
This PR adds a Boolean attribute to arc and task entities, so that tasks and arcs may be marked as "complete". As a clarifying note, booleans are stored as `INTEGER` in SQLite, with `0` being `false` and `1` being `true`. I have defaulted these values to `false` in the class's constructors, assuming that when creating an arc or task, it is unlikely that it will already be complete. I have also updated the DB test on the Wiki (a copy of which is now in the docs folder on this branch).