### PR TITLE
Add complete task/arc functions

### DIFF
--- a/client/src/arcplanner/lib/model/arc.dart
+++ b/client/src/arcplanner/lib/model/arc.dart
@@ -174,4 +174,16 @@ class Arc {
     });
     subArcs.clear(); 
   }
+
+  /*
+  * Description: Updates the SQLite related arc completed field to true. It then also changes its on instance variable to true.
+  */
+  void completeArc() {
+    var db = new DatabaseHelper();
+
+    _completed = true;
+    
+    // Update database with updated arc
+    db.updateArc(this);
+  } 
 }

--- a/client/src/arcplanner/lib/model/task.dart
+++ b/client/src/arcplanner/lib/model/task.dart
@@ -5,6 +5,7 @@
  */
 
 import 'package:uuid/uuid.dart';
+import 'package:arcplanner/util/databaseHelper.dart';
 
 class Task {
   // In flutter, underscrore denotes private members
@@ -73,4 +74,16 @@ class Task {
     _location = map["location"];
     _completed = map["completed"];
   }
+
+  /*
+  * Description: Updates the SQLite related task completed field to true. It then also changes its on instance variable to true.
+  */
+  void completeTask() {
+    var db = new DatabaseHelper();
+
+    _completed = true;
+    
+    // Update database with updated task
+    db.updateTask(this);
+  } 
 }


### PR DESCRIPTION
This PR adds the complete arc/task to each respective class. It updates the attribute and then the database. This is counter to our normal operations but there is no current way to update attributes in database without first updating objects. This can be fixed in a future optimization. 

fixes #28 