### PR TITLE
Add Screen UI Coding Specifications

### DIFF
--- a/client/src/arcplanner/lib/screen_about.dart
+++ b/client/src/arcplanner/lib/screen_about.dart
@@ -45,7 +45,7 @@ class _AboutScreenState extends State<AboutScreen> {
           ),
           Container(
             child: Text(
-              'ArcPlanner is an application that helps organize a busy life. It is a planner that will allow users to quickly add and track tasks. These tasks are organized into Arcs, which are long-term or over-reaching tasks such as large projects, classes, or life goals. Where this application differs from other planner apps is in its simplicity to add tasks. Other apps require the user to address multiple input fields such as time, date, location, other people, etc. ArcPlanner allows the user to input tasks all in the same field and then extracts the important information from the string, creates a task in the correct Arc, and adds it to the list of active tasks. In the input string, a user can have the desired Arc, event title, time, and location. The app will be able to extract these entities regardless of their orientation in the string, thus allowing the user to input tasks in the way that seems most natural to them.\n\nArcPlanner developed by team-CGKM\nMembers:\nMatthew Chastain\nJustin Grabowski\nKevin Kelly\nJonathan Middleton\n\nThis application developed as a part of CS 298; Software DevOps course at WCSU in Spring 2019.',
+              'ArcPlanner is an application that helps organize a busy life. It is a planner that will allow users to quickly add and track tasks. These tasks are organized into Arcs, which are long-term or over-reaching tasks such as large projects, classes, or life goals. Where this application differs from other planner apps is in its simplicity to add tasks. Other apps require the user to address multiple input fields such as time, date, location, other people, etc. ArcPlanner allows the user to input tasks all in the same field and then extracts the important information from the string, creates a task in the correct Arc, and adds it to the list of active tasks. In the input string, a user can have the desired Arc, event title, time, and location. The app will be able to extract these entities regardless of their orientation in the string, thus allowing the user to input tasks in the way that seems most natural to them.\n\nArcPlanner developed by team-CGKM\nMembers:\nMatthew Chastain\nJustin Grabowski\nKevin Kelly\nJonathan Middleton\n\nThis application developed as a part of CS 298; Software DevOps course at WCSU in Spring 2019.\n\n',
               style: TextStyle(
                 fontSize: 15,
               ),
@@ -55,8 +55,10 @@ class _AboutScreenState extends State<AboutScreen> {
       ),
         
       floatingActionButton: FloatingActionButton(
-        foregroundColor: Colors.blue,
+        child: Icon(Icons.arrow_back),
+        backgroundColor: Colors.blue,
         onPressed: _toPreviousScreen,
+        mini: true,
       ),
       floatingActionButtonLocation: FloatingActionButtonLocation.endFloat,
     );

--- a/docs/Screen-Coding-Specifications.md
+++ b/docs/Screen-Coding-Specifications.md
@@ -1,0 +1,69 @@
+# ArcPlanner Screen Coding Specifications #
+## Overview ##
+This document specifies different aspects of ArcPlanner screen development, including but not limited to panel height and width, font style and size, and colors.  
+#
+
+## General Tips ##
+* When getting the height and width of a device, using the following code snippets:
+```
+MediaQuery.of(context).size.height
+MediaQuery.of(context).size.width
+```
+#
+
+## Bottom App Bar ##
+#
+
+## Panel Dimensions ##
+Panels include the Arc/SubArc/Task tiles in the Arc and Task Views, Home Screen, and Calendar View.  
+* Panels should span the width of the device's screen
+* Arc/Task panels should be a total of 15% of the screen's height
+#
+
+## Fonts ##
+#
+
+## Help Dialog ##
+* Container should be 80% of the screen's height   
+#
+
+## Buttons ##
+* Use RaisedButton
+* Blue Background
+* RoundedRectangleBorder
+### Example ###
+```
+RaisedButton(
+   onPressed: _sendLogin,
+   color: Colors.blue,
+   shape: RoundedRectangleBorder(
+      borderRadius: BorderRadius.circular(5),
+   ),
+   child: Text(
+      'Login',
+      style: TextStyle(
+      color: Colors.white,
+      fontSize: 22,
+      ),
+   ),
+),
+```
+#
+
+## Floating Buttons ##
+* Use Icons library to specify desired icon
+* Use small size (mini: true)
+* Blue background
+* White Icons
+* onPressed methods need no “()” at the end of the function call and should be given a private member function
+### Example ###
+```
+floatingActionButton: FloatingActionButton(
+   child: Icon(Icons.arrow_back),
+   backgroundColor: Colors.blue,
+   onPressed: _toPreviousScreen,
+   mini: true,
+),
+
+```
+#

--- a/docs/Screen-Coding-Specifications.md
+++ b/docs/Screen-Coding-Specifications.md
@@ -1,34 +1,38 @@
 # ArcPlanner Screen Coding Specifications #
 ## Overview ##
 This document specifies different aspects of ArcPlanner screen development, including but not limited to panel height and width, font style and size, and colors.  
-#
+
 
 ## General Tips ##
+* Wrapping a screen in a `SafeArea` widget avoids the device's OS items, such as the notification bar along the top of Android devices
 * When getting the height and width of a device, using the following code snippets:
 ```
 MediaQuery.of(context).size.height
 MediaQuery.of(context).size.width
 ```
-#
+
 
 ## Bottom App Bar ##
-#
+* If using a bottom bar in a screen, use the default height of the bar
 
 ## Panel Dimensions ##
 Panels include the Arc/SubArc/Task tiles in the Arc and Task Views, Home Screen, and Calendar View.  
 * Panels should span the width of the device's screen
 * Arc/Task panels should be a total of 15% of the screen's height
-#
+
 
 ## Fonts ##
-#
+* Use AutoSizeText Objects when possible for proper scaling
+    * auto_size_text Dart library
+    * `import 'package:auto_size_text/auto_size_text.dart';` after adding to pubspec.yaml
 
 ## Help Dialog ##
-* Container should be 80% of the screen's height   
-#
+* Container should be 80% of the screen's height, 90% of the screen's width, and centered   
+
 
 ## Buttons ##
 * Use RaisedButton
+    * Embedding another structure such as a `Row` in the button allows for adding icons or other items
 * Blue Background
 * RoundedRectangleBorder
 ### Example ###
@@ -48,7 +52,7 @@ RaisedButton(
    ),
 ),
 ```
-#
+
 
 ## Floating Buttons ##
 * Use Icons library to specify desired icon
@@ -66,4 +70,4 @@ floatingActionButton: FloatingActionButton(
 ),
 
 ```
-#
+

--- a/docs/Screen-Coding-Specifications.md
+++ b/docs/Screen-Coding-Specifications.md
@@ -15,10 +15,11 @@ MediaQuery.of(context).size.width
 ## Bottom App Bar ##
 * If using a bottom bar in a screen, use the default height of the bar
 
-## Panel Dimensions ##
+## Panels/Tiles ##
 Panels include the Arc/SubArc/Task tiles in the Arc and Task Views, Home Screen, and Calendar View.  
 * Panels should span the width of the device's screen
 * Arc/Task panels should be a total of 15% of the screen's height
+* If a tile needs to be tappable, implement it using the `ListTile` widget
 
 
 ## Fonts ##


### PR DESCRIPTION
Added the ArcPlanner Screen Coding Specifications document to the branch. The purpose of the document is to start conversation about the app's UI style and is open to discussion and changes. This should the place to come to see how certain aspects of screens are built in ArcPlanner. If you come across an aspect of screen design that isn't touched upon in this document, feel free to make a section for it and start a conversation about it. The document as is should give some structure as to how we shape certain screen widgets.

closes #30 