### PR TITLE
Add subarc view

### DIFF
--- a/client/src/arcplanner/lib/src/blocs/bloc.dart
+++ b/client/src/arcplanner/lib/src/blocs/bloc.dart
@@ -24,7 +24,19 @@ class Bloc {
   // Takes in 
   final _arcViewController = StreamController<dynamic>.broadcast();
   Stream<dynamic> get arcViewStream => _arcViewController.stream;
-  Function(dynamic) get arcViewInsert => _arcViewController.sink.add;
+  //Function(dynamic) get arcViewInsert => _arcViewController.sink.add;
+  void arcViewInsert(dynamic obj) {
+    print('getting to sink');
+    _arcViewController.sink.add(obj);
+  } 
+
+  Stream<dynamic> get transformer => _arcViewController.stream.transform(transformData);
+
+  final transformData =
+    StreamTransformer<dynamic, String>.fromHandlers(handleData: (order, sink) {
+      print('getting to transformer');
+      print(order);
+  });
   
   Arc toArc(Map map) {
     return Arc.read(map['UID'], map['AID'], map['Title'], description: 
@@ -83,8 +95,11 @@ class Bloc {
   }
 
   updateArcView(Arc parent, String flag){
+    print('getting here');
+    print("parent title: " + parent.title + " flag: " + flag );
     //flag conditions: getChildren, ...
     if (flag == "getChildren"){
+      print(parent.title);
       getChildren(parent);
     } else if (flag == "getParent"){
         //get parent

--- a/client/src/arcplanner/lib/src/blocs/bloc.dart
+++ b/client/src/arcplanner/lib/src/blocs/bloc.dart
@@ -31,6 +31,8 @@ class Bloc {
     _arcViewController.sink.add(obj);
   } 
 
+  // Map function that based on the given flag from stream will perform
+  //  varying operations that return needed arcs to stream 
   dynamic transformData(data) async {
     if (data['flag'] == "add") {
       return await data['object'];
@@ -106,27 +108,10 @@ class Bloc {
           parent.childrenUUIDs.add(object.tid);
         }
       });
+    } else {
+      parent.childrenUUIDs.forEach((uuid) => children.add(loadedObjects[uuid]));
     }
-    
-    parent.childrenUUIDs.forEach((uuid) => children.add(loadedObjects[uuid]));
     return children;
-  }
-
-  // Performs an action on the arc given by the 'parent' parameter
-  // Flag determines which function to perform with the arc
-  dynamic updateArcView(Arc parent, String flag){
-    //flag conditions: getChildren, ...
-    if (flag == "getChildren"){
-      print(parent.title);
-      getChildren(parent);
-    } else if (flag == "add") {
-      _arcViewController.add(parent);
-    } else if (flag == "getParent"){
-        //get parent
-    } else if (flag == "getParentSiblings"){
-      // get parent's siblings
-    }
-    /*else if... */
   }
 
   // Closes the stream controller

--- a/client/src/arcplanner/lib/src/model/arc.dart
+++ b/client/src/arcplanner/lib/src/model/arc.dart
@@ -16,7 +16,7 @@ class Arc {
   String _description;
   String _parentArc;
   bool _completed;
-  List<String> childrenUUIDs;
+  List<String> childrenUUIDs = new List();
 
   // Constructor
   Arc(this._uid, this._title, {description, parentArc}) {

--- a/client/src/arcplanner/lib/src/ui/arc_view_screen.dart
+++ b/client/src/arcplanner/lib/src/ui/arc_view_screen.dart
@@ -85,6 +85,7 @@ Widget arcTile(Arc arc, BuildContext context) {
 
   return Container(
     decoration: BoxDecoration(
+      color: Colors.grey[300],
       border: Border(
         bottom: BorderSide(),
         top: BorderSide(),
@@ -132,6 +133,13 @@ Widget arcTile(Arc arc, BuildContext context) {
 
 Widget taskTile(Task task, BuildContext context) {
   return Container(
+    decoration: BoxDecoration(
+      color: Colors.grey[300],
+      border: Border(
+        bottom: BorderSide(),
+        top: BorderSide(),
+      ),
+    ),
     height: MediaQuery.of(context).size.height * 0.15,
     child: ListTile(
       title: Column(

--- a/client/src/arcplanner/lib/src/ui/arc_view_screen.dart
+++ b/client/src/arcplanner/lib/src/ui/arc_view_screen.dart
@@ -8,7 +8,6 @@ import 'package:auto_size_text/auto_size_text.dart';
 class ArcViewScreen extends StatelessWidget {
 
   _toTaskView(Task task) {
-
   }
 
   Widget build(context) {
@@ -22,17 +21,22 @@ class ArcViewScreen extends StatelessWidget {
             child: StreamBuilder(
               stream: bloc.arcViewStream,
               builder: (context, snapshot) {
-                if (snapshot.hasData) {
-                  dynamic snapshotData = snapshot.data;
-                  return ListView.builder(
-                    itemCount: snapshotData.length,
-                    itemBuilder: (context, index) {
-                      return tile(snapshotData[index], context);
-                    },
-                  );
-                } else {
-                  return Text('There are no Arcs/Tasks');
-                }
+                return new FutureBuilder(
+                  future: snapshot.data,
+                  builder: (context, snapshot) {
+                    if (snapshot.hasData) {
+                    dynamic snapshotData = snapshot.data;
+                    return ListView.builder(
+                      itemCount: snapshotData.length,
+                      itemBuilder: (context, index) {
+                        return tile(snapshotData[index], context);
+                      },
+                    );
+                    } else {
+                      return Text('There are no Arcs/Tasks');
+                    }
+                  },
+                );
               },
             ),
           ),
@@ -119,7 +123,7 @@ Widget arcTile(Arc arc, BuildContext context) {
         ],
       ),
       onTap: () {
-        bloc.arcViewInsert({ 'object' : arc.aid, 'flag': 'getChildren'});
+        bloc.arcViewInsert({ 'object' : arc, 'flag': 'getChildren'});
       } 
       //onLongPress: ,
     ),

--- a/client/src/arcplanner/lib/src/ui/arc_view_screen.dart
+++ b/client/src/arcplanner/lib/src/ui/arc_view_screen.dart
@@ -80,15 +80,18 @@ class ArcViewScreen extends StatelessWidget {
 Widget arcTile(Arc arc, BuildContext context) {
   var description = arc.description;
   if (description == null) {
-    description = 'Tidy up.';
+    description = '';
   }
 
   return Container(
     decoration: BoxDecoration(
-      color: Colors.grey[300],
       border: Border(
-        bottom: BorderSide(),
-        top: BorderSide(),
+        bottom: BorderSide(
+          color: Colors.grey[350],
+        ),
+        top: BorderSide(
+          color: Colors.grey[350],
+        ),
       ),
     ),
     height: MediaQuery.of(context).size.height * 0.20,
@@ -98,19 +101,25 @@ Widget arcTile(Arc arc, BuildContext context) {
         mainAxisAlignment: MainAxisAlignment.start,
         children: <Widget>[
           Container(
-            padding: EdgeInsets.all(10),
+            padding: EdgeInsets.only(
+              top: 10.0,
+              bottom: 10.0,
+            ),
             child: AutoSizeText(arc.title,
               style: TextStyle(
                 color: Colors.black,
+                fontWeight: FontWeight.bold,
               ),
-              maxFontSize: 20.0,
-              minFontSize: 16.0,
+              maxFontSize: 24.0,
+              minFontSize: 18.0,
               maxLines: 1,
               overflow: TextOverflow.ellipsis,
             ),
           ),
           Container(
-            padding: EdgeInsets.all(10),
+            padding: EdgeInsets.only(
+              bottom: 10.0,
+            ),
             child: AutoSizeText(description,
               style: TextStyle(
                 color: Colors.black,
@@ -132,12 +141,20 @@ Widget arcTile(Arc arc, BuildContext context) {
 }
 
 Widget taskTile(Task task, BuildContext context) {
+  var description = task.description;
+  if (description == null) {
+    description = '';
+  }
+
   return Container(
     decoration: BoxDecoration(
-      color: Colors.grey[300],
       border: Border(
-        bottom: BorderSide(),
-        top: BorderSide(),
+        bottom: BorderSide(
+          color: Colors.grey[350],
+        ),
+        top: BorderSide(
+          color: Colors.grey[350],
+        ),
       ),
     ),
     height: MediaQuery.of(context).size.height * 0.15,
@@ -148,7 +165,10 @@ Widget taskTile(Task task, BuildContext context) {
             children: <Widget>[
               Container(
                 width: MediaQuery.of(context).size.width * 0.7,
-                padding: EdgeInsets.all(10),
+                padding: EdgeInsets.only(
+                  top: 10.0,
+                  bottom: 10.0,
+                ),
                 child: AutoSizeText(task.title,
                   maxFontSize: 20.0,
                   minFontSize: 16.0,
@@ -157,7 +177,9 @@ Widget taskTile(Task task, BuildContext context) {
                 ),
               ),
               Container(
-                padding: EdgeInsets.all(10),
+                padding: EdgeInsets.only(
+                  bottom: 10.0,
+                ),
                 child: AutoSizeText(task.duedate,
                   maxFontSize: 20.0,
                   minFontSize: 16.0,

--- a/client/src/arcplanner/lib/src/ui/arc_view_screen.dart
+++ b/client/src/arcplanner/lib/src/ui/arc_view_screen.dart
@@ -190,6 +190,7 @@ Widget tile(dynamic obj, BuildContext context) {
   } else if (obj is Task) {
     return taskTile(obj, context);
   } else {
+    print(obj);
     return Text('tile tried to build not an Arc or Task');
   }
 }

--- a/client/src/arcplanner/lib/src/util/databaseHelper.dart
+++ b/client/src/arcplanner/lib/src/util/databaseHelper.dart
@@ -148,8 +148,8 @@ class DatabaseHelper {
 
   Future<List<Map>> getChildren(String uuid) async {
     var dbClient = await db;
-    List<Map> list = await dbClient.rawQuery('SELECT * FROM Arc WHERE ParentArc = $uuid');
-    list.addAll(await dbClient.rawQuery('SELECT * FROM Task WHERE ParentArc = $uuid'));
+    List<Map> list = await dbClient.rawQuery('SELECT * FROM Arc WHERE ParentArc = "$uuid"');
+    //list.addAll(await dbClient.rawQuery('SELECT * FROM Task WHERE AID = "$uuid"'));
     return list;
   }
 


### PR DESCRIPTION
This PR adds the ability to move from the "MasterArc" list to a subArc. To do this I had to do the following:

- Add a map function `transformData` to the stream that transforms the data in the stream to the "proper" data object. The "proper" object is determined by a flag that is added into the `stream.sink`
- Modify functions to fit into the above object/flag structure
- Change `getChildren` function to correctly obtain children of given arc from database
- Fix error in `databaseHelper.dart` that was referencing wrong column and wasn't using quotes around string values

closes #57 