### PR TITLE
Add back functionality

### DIFF
--- a/client/src/arcplanner/lib/src/blocs/bloc.dart
+++ b/client/src/arcplanner/lib/src/blocs/bloc.dart
@@ -9,18 +9,7 @@ class Bloc {
   Map<String, dynamic> loadedObjects = Map<String, dynamic>();
 
   // Constructor
-  Bloc() {
-    //initArcView();
-  }
-  
-  // Load the BLoC with records from the database to be used by the app
-  void initArcView() async {
-    insertListIntoMap(await db.getMasterArcs());
-    List<Arc> initialList = new List();
-    loadedObjects.forEach((key, value) {
-      initialList.add(value);
-    });
-  }
+  Bloc();  
 
 
   // Create stream and getters for views to interact with
@@ -41,6 +30,8 @@ class Bloc {
     } else if (data['flag'] == "backButton") {
       Arc parent = getFromMap(data['object']);
       return await getChildren(parent.parentArc);
+    } else if (data['flag'] == "clear") {
+      return null;
     }
   }
   
@@ -90,6 +81,7 @@ class Bloc {
     }
   }
 
+  // Loads Arc or Task from loaded objects map given a UUID
   dynamic getFromMap(String uuid) {
     return loadedObjects[uuid];
   }

--- a/client/src/arcplanner/lib/src/blocs/bloc.dart
+++ b/client/src/arcplanner/lib/src/blocs/bloc.dart
@@ -93,14 +93,14 @@ class Bloc {
   // Checks to see if children are in map. If they exist in map then send them
   //  back via stream. Otherwise load them from database and into map. Then
   //  to the UI via stream
-  Future<List<dynamic>> getChildren (Arc parent) async {
+  Future<List<dynamic>> getChildren (String parentUUID) async {
     List<dynamic> children;
 
     // Get first child UUID and see if it exists. If and only if at 
     //  least 1 child exists in map then all children exists
     if (parent.childrenUUIDs.isEmpty) { // Key does not exist in map yet or doesn't have children
       // Add all children to map
-      children = insertListIntoMap(await db.getChildren(parent.aid));
+      children = insertListIntoMap(await db.getChildren(parentUUID));
       children.forEach((object) {
         if (object is Arc) {
           parent.childrenUUIDs.add(object.aid);

--- a/client/src/arcplanner/lib/src/model/arc.dart
+++ b/client/src/arcplanner/lib/src/model/arc.dart
@@ -4,8 +4,6 @@
  * Provided AS IS. No warranties expressed or implied. Use at your own risk.
  */
 
-import 'task.dart';
-import '../util/databaseHelper.dart';
 import 'package:uuid/uuid.dart';
 
 class Arc {
@@ -28,9 +26,10 @@ class Arc {
 
   // Constructor to build object read from database
   Arc.read(this._uid, this._aid, this._title, 
-      {description, parentArc, completed}) {
+      {description, parentArc, completed, childrenUUIDs}) {
     this._description = description;
     this._parentArc = parentArc;
+    this.childrenUUIDs = childrenUUIDs?.split(",");
     if (completed == '1') {
       this._completed = true;
     } else {

--- a/client/src/arcplanner/lib/src/ui/arc_view_screen.dart
+++ b/client/src/arcplanner/lib/src/ui/arc_view_screen.dart
@@ -6,12 +6,14 @@ import '../model/task.dart';
 import 'package:auto_size_text/auto_size_text.dart';
 
 class ArcViewScreen extends StatelessWidget {
+  static String currentParent = "Home";
 
   _toTaskView(Task task) {
   }
 
   Widget build(context) {
-    String currentParent = "Home";
+    bool firstTimeLoading = true;
+
 
     return Scaffold(
       backgroundColor: Colors.white,
@@ -25,6 +27,10 @@ class ArcViewScreen extends StatelessWidget {
                 return new FutureBuilder(
                   future: snapshot.data,
                   builder: (context, snapshot) {
+                    if (firstTimeLoading) {
+                      bloc.arcViewInsert({ 'object' : null, 'flag': 'getChildren'});
+                      firstTimeLoading = false;
+                    }
                     if (snapshot.hasData) {
                     dynamic snapshotData = snapshot.data;
                     return ListView.builder(
@@ -71,10 +77,10 @@ class ArcViewScreen extends StatelessWidget {
 
       floatingActionButton: FloatingActionButton(
         onPressed: () {
-          if (currentParent == "Home") {
+          if (currentParent == null) {
             Navigator.pop(context);
           } else {
-            bloc.arcViewInsert({ 'object' : currentParent, 'flag': 'getChildren'});
+            bloc.arcViewInsert({ 'object' : currentParent, 'flag': 'backButton'});
           }
         },
       ),
@@ -84,6 +90,10 @@ class ArcViewScreen extends StatelessWidget {
 
 Widget arcTile(Arc arc, BuildContext context) {
   var description = arc.description;
+
+  // TODO move to somewhere where it isnt called more then needed
+  ArcViewScreen.currentParent = arc.parentArc;
+  
   if (description == null) {
     description = '';
   }

--- a/client/src/arcplanner/lib/src/ui/arc_view_screen.dart
+++ b/client/src/arcplanner/lib/src/ui/arc_view_screen.dart
@@ -11,6 +11,7 @@ class ArcViewScreen extends StatelessWidget {
   }
 
   Widget build(context) {
+    String currentParent = "Home";
 
     return Scaffold(
       backgroundColor: Colors.white,
@@ -70,7 +71,11 @@ class ArcViewScreen extends StatelessWidget {
 
       floatingActionButton: FloatingActionButton(
         onPressed: () {
-          Navigator.pop(context);
+          if (currentParent == "Home") {
+            Navigator.pop(context);
+          } else {
+            bloc.arcViewInsert({ 'object' : currentParent, 'flag': 'getChildren'});
+          }
         },
       ),
     );

--- a/client/src/arcplanner/lib/src/ui/arc_view_screen.dart
+++ b/client/src/arcplanner/lib/src/ui/arc_view_screen.dart
@@ -138,7 +138,7 @@ Widget arcTile(Arc arc, BuildContext context) {
         ],
       ),
       onTap: () {
-        bloc.arcViewInsert({ 'object' : arc, 'flag': 'getChildren'});
+        bloc.arcViewInsert({ 'object' : arc.aid, 'flag': 'getChildren'});
       } 
       //onLongPress: ,
     ),

--- a/client/src/arcplanner/lib/src/ui/arc_view_screen.dart
+++ b/client/src/arcplanner/lib/src/ui/arc_view_screen.dart
@@ -7,6 +7,7 @@ import 'package:auto_size_text/auto_size_text.dart';
 
 class ArcViewScreen extends StatelessWidget {
   static String currentParent = "Home";
+  static bool atNoArcTaskScreen = false;
 
   _toTaskView(Task task) {
   }
@@ -31,6 +32,7 @@ class ArcViewScreen extends StatelessWidget {
                       bloc.arcViewInsert({ 'object' : null, 'flag': 'getChildren'});
                       firstTimeLoading = false;
                     }
+                    
                     if (snapshot.hasData) {
                     dynamic snapshotData = snapshot.data;
                     return ListView.builder(
@@ -77,10 +79,15 @@ class ArcViewScreen extends StatelessWidget {
 
       floatingActionButton: FloatingActionButton(
         onPressed: () {
-          if (currentParent == null) {
+          if (currentParent == null && !atNoArcTaskScreen) {
             Navigator.pop(context);
           } else {
-            bloc.arcViewInsert({ 'object' : currentParent, 'flag': 'backButton'});
+            if (atNoArcTaskScreen) {
+              bloc.arcViewInsert({ 'object' : currentParent, 'flag': 'getChildren'});
+              atNoArcTaskScreen = false;
+            } 
+            else
+              bloc.arcViewInsert({ 'object' : currentParent, 'flag': 'backButton'});
           }
         },
       ),
@@ -148,7 +155,13 @@ Widget arcTile(Arc arc, BuildContext context) {
         ],
       ),
       onTap: () {
-        bloc.arcViewInsert({ 'object' : arc.aid, 'flag': 'getChildren'});
+        //If going to a screen that shows no children then set flag to true
+        if (arc.childrenUUIDs?.isEmpty ?? true) {
+          ArcViewScreen.atNoArcTaskScreen = true;
+          bloc.arcViewInsert({ 'object' : null, 'flag': 'clear'});
+        } else {
+          bloc.arcViewInsert({ 'object' : arc.aid, 'flag': 'getChildren'});
+        }
       } 
       //onLongPress: ,
     ),
@@ -249,7 +262,6 @@ Widget tile(dynamic obj, BuildContext context) {
   } else if (obj is Task) {
     return taskTile(obj, context);
   } else {
-    print(obj);
     return Text('tile tried to build not an Arc or Task');
   }
 }

--- a/client/src/arcplanner/lib/src/util/databaseHelper.dart
+++ b/client/src/arcplanner/lib/src/util/databaseHelper.dart
@@ -169,7 +169,6 @@ class DatabaseHelper {
   Future<List<Map>> getChildren(String uuid) async {
     var dbClient = await db;
     List<Map> arcList = await dbClient.rawQuery('SELECT * FROM Arc WHERE ParentArc = "$uuid"');
-
     if (uuid != null) {
       List<Map> taskList = await dbClient.rawQuery('SELECT * FROM Task WHERE AID = "$uuid"');
       return new List.from(arcList)..addAll(taskList);

--- a/client/src/arcplanner/lib/src/util/databaseHelper.dart
+++ b/client/src/arcplanner/lib/src/util/databaseHelper.dart
@@ -33,7 +33,8 @@ class DatabaseHelper {
   static final String _userLastName = "LastName";
   static final String _userEmail = "Email";
 
-  static final String _arcTable = "Arc";
+  static final String _arcTable = "Arc_t";
+  static final String _arcView = "Arc";
   static final String _arcUID = "UID";
   static final String _arcAID = "AID";
   static final String _arcTitle = "Title";
@@ -98,6 +99,22 @@ class DatabaseHelper {
           $_taskLoc TEXT CHECK(LENGTH($_taskLoc) <= $_locSize),
           $_taskCompleted INTEGER CHECK($_taskCompleted == 0 OR $_taskCompleted == 1)
           )""");
+    await db.execute("""
+        CREATE VIEW $_arcView AS
+        SELECT UID, AID, Title, Description, ParentArc, Completed, 
+          ( SELECT group_concat(UUID)
+            FROM (
+              SELECT Arc2.AID AS UUID
+              FROM Arc_t AS Arc2
+              WHERE Arc2.ParentArc = Arc1.AID AND Arc2.ParentArc IS NOT NULL
+              UNION
+              SELECT TID As UUID
+              FROM Task
+              WHERE Task.AID = Arc1.UID
+          )
+        ) As ChildrenUUIDs
+        FROM Arc_t AS Arc1
+        """);
     print("Tables created");
   }
 
@@ -151,20 +168,7 @@ class DatabaseHelper {
   // given a UUID, returns a list of mapped children
   Future<List<Map>> getChildren(String uuid) async {
     var dbClient = await db;
-    List<Map> arcList = await dbClient.rawQuery("""
-      SELECT UID, AID, Title, Description, ParentArc, Completed, 
-        ( group_concat (
-          SELECT AID
-          FROM Arc
-          WHERE ParentArc = "$uuid" AND IS NOT NULL
-          UNION
-          SELECT TID
-          FROM Task
-          WHERE AID = "$uuid"
-        )) AS ChildrenUUIDs
-      FROM Arc 
-      WHERE AID = "$uuid"
-      """);
+    List<Map> arcList = await dbClient.rawQuery('SELECT * FROM Arc WHERE ParentArc = "$uuid"');
 
     if (uuid != null) {
       List<Map> taskList = await dbClient.rawQuery('SELECT * FROM Task WHERE AID = "$uuid"');


### PR DESCRIPTION
This PR addresses multiple issues: #63 and #67 . The back button now works correctly and going to the arc view after viewing other screens/leaving arc view will also now work. 

The changes needed for these fixes:
- Removed unneeded `initMap` function and instead used current `getChildren` functionality with null values. 
- Added two new flags to arc view stream, `backButton` and `clear`. `backButton` is used to go back a level with `getChildren`. `Clear` sends a null to the stream which clears the screen. 
- Added a view that selects all fields of Arc table , now called `arc_t`, and adds the attribute `ChildrenUUIDS` which is a list of all children UUIDs of that arc. This field was added to the Arc constructor `Read`.
- Added some helper functions in BLoC for loading objects from map
- Modified `GetChildren` to work with new view and flags
- Making back button work with stateless widgets was a bit hard but I have it working. Please review this in detail as I am unsure if this is the best approach. 

Closes #63, Closes #67 