### PR TITLE
Add arc creation screen

### DIFF
--- a/client/src/arcplanner/lib/src/arcplanner.dart
+++ b/client/src/arcplanner/lib/src/arcplanner.dart
@@ -5,6 +5,7 @@ import 'ui/about_screen.dart';
 import 'ui/home_screen.dart';
 import 'ui/settings_screen.dart';
 import 'ui/arc_view_screen.dart';
+import 'ui/add_arc_screen.dart';
 
 /// Observer for tracking page changes
 final RouteObserver<PageRoute> routeObserver = RouteObserver<PageRoute>();
@@ -16,6 +17,7 @@ class ArcPlanner extends StatelessWidget {
   static HomeScreen homeScreen = HomeScreen();
   static SettingsScreen settingsScreen = SettingsScreen();
   static ArcViewScreen arcViewScreen = ArcViewScreen();
+  static AddArcScreen addArcScreen = AddArcScreen();
 
   Widget build(BuildContext context) {
     return MaterialApp(
@@ -32,6 +34,7 @@ class ArcPlanner extends StatelessWidget {
         '/home': (BuildContext context) => homeScreen,
         '/settings': (BuildContext context) => settingsScreen,
         '/arcview': (BuildContext context) => arcViewScreen,
+        '/addarc': (BuildContext context) => addArcScreen,
       },
       navigatorObservers: [routeObserver],
     );

--- a/client/src/arcplanner/lib/src/blocs/bloc.dart
+++ b/client/src/arcplanner/lib/src/blocs/bloc.dart
@@ -9,7 +9,7 @@ import 'package:rxdart/rxdart.dart';
 class Bloc {
   final DatabaseHelper db = DatabaseHelper();
   Map<String, dynamic> loadedObjects = Map<String, dynamic>();
-
+  
   // Constructor
   Bloc() {
     initMap();
@@ -42,8 +42,8 @@ class Bloc {
 
   Stream<dynamic> get arcDescriptionFieldStream => _arcDescriptionFieldController.stream;
 
-  //Stream<bool> get submitValidArc =>
-    //  Observable.combineLatest4(arcLocationFieldStream, arcTitleFieldStream, ///arcEndDateFieldStream, arcDescriptionFieldStream, (l, t, e, d) => true);
+  Stream<bool> get submitValidArc =>
+      Observable.combineLatest4(arcLocationFieldStream, arcTitleFieldStream, arcEndDateFieldStream, arcDescriptionFieldStream, (l, t, e, d) => true);
 
   Function(String) get changeLocation => _arcLocationFieldController.sink.add;
   Function(String) get changeTitle => _arcTitleFieldController.sink.add;
@@ -142,6 +142,10 @@ class Bloc {
     final arcTitle = _arcTitleFieldController.value;
     final arcEndDate = _arcEndDateFieldController.value;
     final arcDescription = _arcEndDateFieldController.value;
+
+
+    //TODO create arc with new data
+    //TODO insert to new arc
   }
 
   // Closes the stream controller

--- a/client/src/arcplanner/lib/src/blocs/bloc.dart
+++ b/client/src/arcplanner/lib/src/blocs/bloc.dart
@@ -2,17 +2,20 @@
 import 'dart:async';
 import '../model/arc.dart';
 import '../model/task.dart';
+//import '../model/user.dart';
 import '../util/databaseHelper.dart';
+import '../blocs/validators.dart';
 import 'package:rxdart/rxdart.dart';
 
 
-class Bloc {
+class Bloc extends Object with Validators {
   final DatabaseHelper db = DatabaseHelper();
   Map<String, dynamic> loadedObjects = Map<String, dynamic>();
   
   // Constructor
   Bloc() {
     initMap();
+    //?TODO create user?
   }
   
   // Load the BLoC with records from the database to be used by the app
@@ -27,24 +30,29 @@ class Bloc {
 
   // Create stream and getters for views to interact with
   final _arcViewController = StreamController<dynamic>.broadcast();
-  final _arcLocationFieldController = BehaviorSubject<dynamic>();
-  final _arcTitleFieldController = BehaviorSubject<dynamic>();
-  final _arcEndDateFieldController = BehaviorSubject<dynamic>();
-  final _arcDescriptionFieldController = BehaviorSubject<dynamic>();
+
+  // Streams for add_arc_screen
+  final _arcLocationFieldController = BehaviorSubject<String>();
+  final _arcTitleFieldController = BehaviorSubject<String>();
+  final _arcEndDateFieldController = BehaviorSubject<String>();
+  final _arcDescriptionFieldController = BehaviorSubject<String>();
   
   Stream<dynamic> get arcViewStream => _arcViewController.stream.map(transformData);
 
-  Stream<dynamic> get arcLocationFieldStream => _arcLocationFieldController.stream;
+  // Add data to streams for Add Arc Screen
+  Stream<String> get arcLocationFieldStream => _arcLocationFieldController.stream;
 
-  Stream<dynamic> get arcTitleFieldStream => _arcTitleFieldController.stream;
+  Stream<String> get arcTitleFieldStream => _arcTitleFieldController.stream.transform(validateTitle);
 
-  Stream<dynamic> get arcEndDateFieldStream => _arcEndDateFieldController.stream;
+  Stream<String> get arcEndDateFieldStream => _arcEndDateFieldController.stream;
 
-  Stream<dynamic> get arcDescriptionFieldStream => _arcDescriptionFieldController.stream;
+  Stream<String> get arcDescriptionFieldStream => _arcDescriptionFieldController.stream;
 
   Stream<bool> get submitValidArc =>
-      Observable.combineLatest4(arcLocationFieldStream, arcTitleFieldStream, arcEndDateFieldStream, arcDescriptionFieldStream, (l, t, e, d) => true);
+      Observable.combineLatest2(arcTitleFieldStream, 
+    arcDescriptionFieldStream, (t, d) => true);
 
+  // Change data for Add Arc Screen
   Function(String) get changeLocation => _arcLocationFieldController.sink.add;
   Function(String) get changeTitle => _arcTitleFieldController.sink.add;
   Function(String) get changeEndDate => _arcEndDateFieldController.sink.add;
@@ -139,18 +147,23 @@ class Bloc {
 
   submitArc() {
     final arcLoc = _arcLocationFieldController.value;
-    final arcTitle = _arcTitleFieldController.value;
+    final validArcTitle = _arcTitleFieldController.value;
     final arcEndDate = _arcEndDateFieldController.value;
     final arcDescription = _arcEndDateFieldController.value;
 
-
+    print("$validArcTitle");
     //TODO create arc with new data
+    //User sally = new User("sally", "seashells", "this@that.com");
+    //Arc ar = new Arc(sally.uid, validArcTitle);
+    //db.insertArc(ar);
     //TODO insert to new arc
   }
 
   // Closes the stream controller
   dispose() {
     _arcViewController.close();
+
+    // Close Add Arc Screen streams
     _arcDescriptionFieldController.close();
     _arcEndDateFieldController.close();
     _arcLocationFieldController.close();

--- a/client/src/arcplanner/lib/src/blocs/bloc.dart
+++ b/client/src/arcplanner/lib/src/blocs/bloc.dart
@@ -36,6 +36,7 @@ class Bloc extends Object with Validators {
   final _arcTitleFieldController = BehaviorSubject<String>();
   final _arcEndDateFieldController = BehaviorSubject<String>();
   final _arcDescriptionFieldController = BehaviorSubject<String>();
+  final _arcParentFieldController = BehaviorSubject<Arc>();
   
   Stream<dynamic> get arcViewStream => _arcViewController.stream.map(transformData);
 
@@ -48,6 +49,8 @@ class Bloc extends Object with Validators {
 
   Stream<String> get arcDescriptionFieldStream => _arcDescriptionFieldController.stream;
 
+  Stream<Arc> get arcParentFieldStream => _arcParentFieldController.stream;
+
   Stream<bool> get submitValidArc =>
       Observable.combineLatest2(arcTitleFieldStream, 
     arcDescriptionFieldStream, (t, d) => true);
@@ -57,6 +60,7 @@ class Bloc extends Object with Validators {
   Function(String) get changeTitle => _arcTitleFieldController.sink.add;
   Function(String) get changeEndDate => _arcEndDateFieldController.sink.add;
   Function(String) get changeDescription => _arcDescriptionFieldController.sink.add;
+  Function(Arc) get changeParent => _arcParentFieldController.sink.add;
 
   void arcViewInsert(dynamic obj) {
     _arcViewController.sink.add(obj);
@@ -169,6 +173,7 @@ class Bloc extends Object with Validators {
     _arcLocationFieldController.close();
     _arcTitleFieldController.close();
     _arcViewController.close();
+    _arcParentFieldController.close();
   }
 }
 

--- a/client/src/arcplanner/lib/src/blocs/bloc.dart
+++ b/client/src/arcplanner/lib/src/blocs/bloc.dart
@@ -3,6 +3,8 @@ import 'dart:async';
 import '../model/arc.dart';
 import '../model/task.dart';
 import '../util/databaseHelper.dart';
+import 'package:rxdart/rxdart.dart';
+
 
 class Bloc {
   final DatabaseHelper db = DatabaseHelper();
@@ -25,8 +27,29 @@ class Bloc {
 
   // Create stream and getters for views to interact with
   final _arcViewController = StreamController<dynamic>.broadcast();
-  Stream<dynamic> get arcViewStream => _arcViewController.stream.map(transformData);
+  final _arcLocationFieldController = BehaviorSubject<dynamic>();
+  final _arcTitleFieldController = BehaviorSubject<dynamic>();
+  final _arcEndDateFieldController = BehaviorSubject<dynamic>();
+  final _arcDescriptionFieldController = BehaviorSubject<dynamic>();
   
+  Stream<dynamic> get arcViewStream => _arcViewController.stream.map(transformData);
+
+  Stream<dynamic> get arcLocationFieldStream => _arcLocationFieldController.stream;
+
+  Stream<dynamic> get arcTitleFieldStream => _arcTitleFieldController.stream;
+
+  Stream<dynamic> get arcEndDateFieldStream => _arcEndDateFieldController.stream;
+
+  Stream<dynamic> get arcDescriptionFieldStream => _arcDescriptionFieldController.stream;
+
+  //Stream<bool> get submitValidArc =>
+    //  Observable.combineLatest4(arcLocationFieldStream, arcTitleFieldStream, ///arcEndDateFieldStream, arcDescriptionFieldStream, (l, t, e, d) => true);
+
+  Function(String) get changeLocation => _arcLocationFieldController.sink.add;
+  Function(String) get changeTitle => _arcTitleFieldController.sink.add;
+  Function(String) get changeEndDate => _arcEndDateFieldController.sink.add;
+  Function(String) get changeDescription => _arcDescriptionFieldController.sink.add;
+
   void arcViewInsert(dynamic obj) {
     _arcViewController.sink.add(obj);
   } 
@@ -114,8 +137,20 @@ class Bloc {
     return children;
   }
 
+  submitArc() {
+    final arcLoc = _arcLocationFieldController.value;
+    final arcTitle = _arcTitleFieldController.value;
+    final arcEndDate = _arcEndDateFieldController.value;
+    final arcDescription = _arcEndDateFieldController.value;
+  }
+
   // Closes the stream controller
   dispose() {
+    _arcViewController.close();
+    _arcDescriptionFieldController.close();
+    _arcEndDateFieldController.close();
+    _arcLocationFieldController.close();
+    _arcTitleFieldController.close();
     _arcViewController.close();
   }
 }

--- a/client/src/arcplanner/lib/src/blocs/validators.dart
+++ b/client/src/arcplanner/lib/src/blocs/validators.dart
@@ -1,0 +1,25 @@
+import 'dart:async';
+
+
+class Validators {
+
+  final validateTitle = 
+    StreamTransformer<String, String>.fromHandlers(handleData: (title, sink) {
+      if (title.isNotEmpty)  {
+        sink.add(title);
+      } else {
+        sink.addError('Please enter a title');
+      }
+    });
+
+    final validateDesc = 
+    StreamTransformer<String, String>.fromHandlers(handleData: (desc, sink) {
+        if (desc.isNotEmpty)  {
+        sink.add(desc);
+      } else {
+        sink.addError('Please enter a description');
+      }
+    });
+
+ 
+}

--- a/client/src/arcplanner/lib/src/model/arc.dart
+++ b/client/src/arcplanner/lib/src/model/arc.dart
@@ -28,7 +28,7 @@ class Arc {
 
   // Constructor to build object read from database
   Arc.read(this._uid, this._aid, this._title, 
-      {description, dueDate, parentArc, completed}) {
+      {description, dueDate, parentArc, completed, childrenUUIDs}) {
     this._description = description;
     this._dueDate = dueDate;
     this._parentArc = parentArc;

--- a/client/src/arcplanner/lib/src/ui/add_arc_screen.dart
+++ b/client/src/arcplanner/lib/src/ui/add_arc_screen.dart
@@ -14,7 +14,9 @@ class AddArcScreen extends StatelessWidget {
             locationField(),
             titleField(), //name
             endDate(),
-            descriptionField()
+            descriptionField(),
+            Container(margin: EdgeInsets.only(top: 25)),
+            submitArc(),
           ],
         ),
       ),
@@ -88,7 +90,7 @@ Widget descriptionField(){
       //End date
       //Description
       return TextField(
-        maxLines: 10,
+        maxLines: 7,
         onChanged: bloc.changeTitle,
         decoration: InputDecoration(
           hintText: 'Description'
@@ -99,4 +101,18 @@ Widget descriptionField(){
   );
 }
 
-
+Widget submitArc() {
+  return StreamBuilder(
+    stream: bloc.submitValidArc, 
+    builder: (context, snapshot){
+      return RaisedButton(
+        child: Text('Submit'),
+        color: Colors.blue,
+        onPressed: () {
+            snapshot.hasData ? bloc.submitArc() : null;
+            Navigator.pop(context);
+          }
+        );
+      },
+  );
+}

--- a/client/src/arcplanner/lib/src/ui/add_arc_screen.dart
+++ b/client/src/arcplanner/lib/src/ui/add_arc_screen.dart
@@ -1,8 +1,12 @@
 import 'package:flutter/material.dart';
 import '../blocs/bloc.dart';
+import '../model/arc.dart';
+import 'drawer_menu.dart';
+import 'package:auto_size_text/auto_size_text.dart';
 
 
 class AddArcScreen extends StatelessWidget {
+  
 
   Widget build(context) {
 
@@ -12,13 +16,32 @@ class AddArcScreen extends StatelessWidget {
         child: Column(
           children:[
             Container(margin: EdgeInsets.only(top: 20)),
-            locationField(),
             titleField(), //name
             //endDate(),
             descriptionField(),
+            Container(
+              margin: EdgeInsets.only(top: 20),
+              child: Row( 
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children:[ 
+                  parentField(),
+                  Flexible(
+                    child: Container(
+                      width:MediaQuery.of(context).size.width * 0.4 , 
+                      child: arcList(),
+                    ),
+                  ),   
+                ]
+              ),
+            ),
+            //parentField(),
+            //arcList(),
           ],
         ),
       ),
+
+      drawer: drawerMenu(context),
+
       bottomNavigationBar: BottomAppBar(
         color: Colors.blue,
         child: Row(
@@ -59,6 +82,7 @@ class AddArcScreen extends StatelessWidget {
     );
  }
 
+
  Widget titleField(){
   return StreamBuilder(
     stream: bloc.arcTitleFieldStream,
@@ -81,14 +105,14 @@ class AddArcScreen extends StatelessWidget {
 
 Widget endDate(){
   return StreamBuilder(
-    stream: bloc.arcTitleFieldStream,
+    stream: bloc.arcEndDateFieldStream,
     builder: (context, snapshot) {
       //Location
       //Name
       //End date
       //Description
       return TextField(
-        onChanged: bloc.changeTitle,
+        onChanged: bloc.changeEndDate,
         decoration: InputDecoration(
           hintText: 'EndDate'
           //errorText: snapshot.error,
@@ -100,7 +124,7 @@ Widget endDate(){
 
 Widget descriptionField(){
   return StreamBuilder(
-    stream: bloc.arcTitleFieldStream,
+    stream: bloc.arcDescriptionFieldStream,
     builder: (context, snapshot) {
       //Location
       //Name
@@ -116,6 +140,75 @@ Widget descriptionField(){
         ),
       );
     }
+  );
+}
+
+ Widget parentField(){
+  return StreamBuilder(
+      stream: bloc.arcParentFieldStream,
+      builder: (context, snapshot) {
+        return Text(snapshot.hasData? snapshot.data.title : "Parent");
+      }
+    );
+ }
+
+Widget arcList() {
+  
+String _arcTitle;
+
+  return StreamBuilder(
+    stream: bloc.arcViewStream,
+    builder: (context, snapshot) {
+      return new FutureBuilder(
+        future: snapshot.data,
+        builder: (context, AsyncSnapshot<dynamic> snapshot) {
+          if (snapshot.hasData) {
+          dynamic snapshotData = snapshot.data;
+          return DropdownButton<dynamic>(
+            hint: Text("Select Parent Arc"),
+            value: _arcTitle,
+            onChanged: (value) {
+              bloc.changeParent(value);
+              print("$value");
+            },
+            isExpanded: true,
+            items: List<DropdownMenuItem<dynamic>>.generate(
+            snapshotData.length,
+              (int index) => DropdownMenuItem<dynamic>(
+                value: snapshotData[index],
+                child: Text(snapshotData[index].title),
+              ),
+            ),
+          );
+           } else {
+            return Text('There are no Arcs/Tasks');
+          }   
+        },
+      );
+    },
+  );
+}
+
+Widget arcTile(Arc arc, BuildContext context) {
+  var description = arc.description;
+  if (description == null) {
+    description = '';
+  }
+
+  return Container(
+    decoration: BoxDecoration(
+      border: Border(
+        bottom: BorderSide(
+          color: Colors.grey[350],
+        ),
+        top: BorderSide(
+          color: Colors.grey[350],
+        ),
+      ),
+    ),
+    child: ListTile(
+      title: Text(arc.title),
+    ),
   );
 }
 

--- a/client/src/arcplanner/lib/src/ui/add_arc_screen.dart
+++ b/client/src/arcplanner/lib/src/ui/add_arc_screen.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/material.dart';
+import '../blocs/bloc.dart';
+
+
+class AddArcScreen extends StatelessWidget {
+
+  Widget build(context) {
+
+    return Scaffold(
+      body: Container(
+        margin: EdgeInsets.all(20.0),
+        child: Column(
+          children:[
+            locationField(),
+            titleField(), //name
+            endDate(),
+            descriptionField()
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+ Widget locationField(){
+  return StreamBuilder(
+      stream: bloc.arcTitleFieldStream,
+      builder: (context, snapshot) {
+        //Location
+        //Name
+        //End date
+        //Description
+        return TextField(
+          onChanged: bloc.changeTitle,
+          decoration: InputDecoration(
+            hintText: 'Location'
+            //errorText: snapshot.error,
+          ),
+        );
+      }
+    );
+ }
+
+ Widget titleField(){
+  return StreamBuilder(
+    stream: bloc.arcTitleFieldStream,
+    builder: (context, snapshot) {
+      //Location
+      //Name
+      //End date
+      //Description
+      return TextField(
+        onChanged: bloc.changeTitle,
+        decoration: InputDecoration(
+          hintText: 'Title'
+          //errorText: snapshot.error,
+        ),
+      );
+    }
+  );
+}
+
+Widget endDate(){
+  return StreamBuilder(
+    stream: bloc.arcTitleFieldStream,
+    builder: (context, snapshot) {
+      //Location
+      //Name
+      //End date
+      //Description
+      return TextField(
+        onChanged: bloc.changeTitle,
+        decoration: InputDecoration(
+          hintText: 'EndDate'
+          //errorText: snapshot.error,
+        ),
+      );
+    }
+  );
+}
+
+Widget descriptionField(){
+  return StreamBuilder(
+    stream: bloc.arcTitleFieldStream,
+    builder: (context, snapshot) {
+      //Location
+      //Name
+      //End date
+      //Description
+      return TextField(
+        maxLines: 10,
+        onChanged: bloc.changeTitle,
+        decoration: InputDecoration(
+          hintText: 'Description'
+          //errorText: snapshot.error,
+        ),
+      );
+    }
+  );
+}
+
+

--- a/client/src/arcplanner/lib/src/ui/add_arc_screen.dart
+++ b/client/src/arcplanner/lib/src/ui/add_arc_screen.dart
@@ -20,10 +20,11 @@ class AddArcScreen extends StatelessWidget {
       
       body: Container(
         margin: EdgeInsets.only(left: 15.0, right: 15.0),
-        child: Column(
+        child: ListView(
           children:[
             Container(margin: EdgeInsets.only(top: 20)),
             titleField(),
+            dueDate(),
             descriptionField(),
             Container(
               margin: EdgeInsets.only(top: 20),
@@ -91,14 +92,15 @@ class AddArcScreen extends StatelessWidget {
   );
 }
 
-Widget endDate(){
+Widget dueDate(){
   return StreamBuilder(
     stream: bloc.arcEndDateFieldStream,
     builder: (context, snapshot) {
       return TextField(
+        keyboardType: TextInputType.datetime,
         onChanged: bloc.changeEndDate,
         decoration: InputDecoration(
-          hintText: 'EndDate'
+          hintText: 'Due Date'
           //TODO add errorText when used
         ),
       );

--- a/client/src/arcplanner/lib/src/ui/add_arc_screen.dart
+++ b/client/src/arcplanner/lib/src/ui/add_arc_screen.dart
@@ -11,11 +11,26 @@ class AddArcScreen extends StatelessWidget {
         margin: EdgeInsets.all(20.0),
         child: Column(
           children:[
+            Container(margin: EdgeInsets.only(top: 20)),
             locationField(),
             titleField(), //name
-            endDate(),
+            //endDate(),
             descriptionField(),
-            Container(margin: EdgeInsets.only(top: 25)),
+          ],
+        ),
+      ),
+      bottomNavigationBar: BottomAppBar(
+        color: Colors.blue,
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+          children: <Widget>[
+            RaisedButton(
+              child: Text('Cancel'),
+              color: Colors.white,
+              textColor: Colors.blue,
+              // Needs to open New Task dialog
+              onPressed: () {Navigator.pop(context);},
+            ),
             submitArc(),
           ],
         ),
@@ -34,6 +49,7 @@ class AddArcScreen extends StatelessWidget {
         //Description
         return TextField(
           onChanged: bloc.changeTitle,
+          keyboardType: TextInputType.datetime,
           decoration: InputDecoration(
             hintText: 'Location'
             //errorText: snapshot.error,
@@ -53,9 +69,10 @@ class AddArcScreen extends StatelessWidget {
       //Description
       return TextField(
         onChanged: bloc.changeTitle,
+        keyboardType: TextInputType.text,
         decoration: InputDecoration(
-          hintText: 'Title'
-          //errorText: snapshot.error,
+          hintText: 'Title',
+          errorText: snapshot.error,
         ),
       );
     }
@@ -91,10 +108,11 @@ Widget descriptionField(){
       //Description
       return TextField(
         maxLines: 7,
-        onChanged: bloc.changeTitle,
+        onChanged: bloc.changeDescription,
+        keyboardType: TextInputType.multiline,
         decoration: InputDecoration(
-          hintText: 'Description'
-          //errorText: snapshot.error,
+          hintText: 'Description',
+          errorText: snapshot.error,
         ),
       );
     }
@@ -107,12 +125,23 @@ Widget submitArc() {
     builder: (context, snapshot){
       return RaisedButton(
         child: Text('Submit'),
-        color: Colors.blue,
-        onPressed: () {
-            snapshot.hasData ? bloc.submitArc() : null;
-            Navigator.pop(context);
+        color: Colors.white,
+        textColor: Colors.blue,
+        onPressed: snapshot.hasData ? (){ 
+          bloc.submitArc;
+          Navigator.pop(context);
           }
-        );
-      },
+        :  null //(){print(snapshot.data);
+        //}
+        /*(){
+          if(snapshot.hasData) {
+             bloc.submitArc();
+            Navigator.pop(context);
+          } else {null;}
+          
+        },
+        */
+      );
+    },
   );
 }

--- a/client/src/arcplanner/lib/src/ui/add_arc_screen.dart
+++ b/client/src/arcplanner/lib/src/ui/add_arc_screen.dart
@@ -2,22 +2,28 @@ import 'package:flutter/material.dart';
 import '../blocs/bloc.dart';
 import '../model/arc.dart';
 import 'drawer_menu.dart';
-import 'package:auto_size_text/auto_size_text.dart';
 
 
 class AddArcScreen extends StatelessWidget {
   
-
   Widget build(context) {
 
     return Scaffold(
+      appBar: AppBar(
+        actions: <Widget>[
+          IconButton(
+            icon: Icon(Icons.cancel),
+            onPressed: () {Navigator.pop(context);},
+          )
+        ],
+      ),
+      
       body: Container(
-        margin: EdgeInsets.all(20.0),
+        margin: EdgeInsets.only(left: 15.0, right: 15.0),
         child: Column(
           children:[
             Container(margin: EdgeInsets.only(top: 20)),
-            titleField(), //name
-            //endDate(),
+            titleField(),
             descriptionField(),
             Container(
               margin: EdgeInsets.only(top: 20),
@@ -33,9 +39,8 @@ class AddArcScreen extends StatelessWidget {
                   ),   
                 ]
               ),
+              //TODO: add additional fields as needed
             ),
-            //parentField(),
-            //arcList(),
           ],
         ),
       ),
@@ -47,13 +52,6 @@ class AddArcScreen extends StatelessWidget {
         child: Row(
           mainAxisAlignment: MainAxisAlignment.spaceEvenly,
           children: <Widget>[
-            RaisedButton(
-              child: Text('Cancel'),
-              color: Colors.white,
-              textColor: Colors.blue,
-              // Needs to open New Task dialog
-              onPressed: () {Navigator.pop(context);},
-            ),
             submitArc(),
           ],
         ),
@@ -66,31 +64,21 @@ class AddArcScreen extends StatelessWidget {
   return StreamBuilder(
       stream: bloc.arcTitleFieldStream,
       builder: (context, snapshot) {
-        //Location
-        //Name
-        //End date
-        //Description
         return TextField(
           onChanged: bloc.changeTitle,
           keyboardType: TextInputType.datetime,
           decoration: InputDecoration(
             hintText: 'Location'
-            //errorText: snapshot.error,
           ),
         );
       }
     );
  }
 
-
  Widget titleField(){
   return StreamBuilder(
     stream: bloc.arcTitleFieldStream,
     builder: (context, snapshot) {
-      //Location
-      //Name
-      //End date
-      //Description
       return TextField(
         onChanged: bloc.changeTitle,
         keyboardType: TextInputType.text,
@@ -107,15 +95,11 @@ Widget endDate(){
   return StreamBuilder(
     stream: bloc.arcEndDateFieldStream,
     builder: (context, snapshot) {
-      //Location
-      //Name
-      //End date
-      //Description
       return TextField(
         onChanged: bloc.changeEndDate,
         decoration: InputDecoration(
           hintText: 'EndDate'
-          //errorText: snapshot.error,
+          //TODO add errorText when used
         ),
       );
     }
@@ -126,14 +110,12 @@ Widget descriptionField(){
   return StreamBuilder(
     stream: bloc.arcDescriptionFieldStream,
     builder: (context, snapshot) {
-      //Location
-      //Name
-      //End date
-      //Description
       return TextField(
         maxLines: 7,
         onChanged: bloc.changeDescription,
         keyboardType: TextInputType.multiline,
+        textInputAction: TextInputAction.done,
+        autocorrect: true,
         decoration: InputDecoration(
           hintText: 'Description',
           errorText: snapshot.error,
@@ -165,7 +147,6 @@ String _arcTitle;
           if (snapshot.hasData) {
           dynamic snapshotData = snapshot.data;
           return DropdownButton<dynamic>(
-            hint: Text("Select Parent Arc"),
             value: _arcTitle,
             onChanged: (value) {
               bloc.changeParent(value);
@@ -214,26 +195,17 @@ Widget arcTile(Arc arc, BuildContext context) {
 
 Widget submitArc() {
   return StreamBuilder(
-    stream: bloc.submitValidArc, 
+    stream: bloc.arcTitleFieldStream, 
     builder: (context, snapshot){
       return RaisedButton(
         child: Text('Submit'),
         color: Colors.white,
         textColor: Colors.blue,
         onPressed: snapshot.hasData ? (){ 
-          bloc.submitArc;
+          bloc.submitArc; //Currently just returns to previous screen
           Navigator.pop(context);
           }
-        :  null //(){print(snapshot.data);
-        //}
-        /*(){
-          if(snapshot.hasData) {
-             bloc.submitArc();
-            Navigator.pop(context);
-          } else {null;}
-          
-        },
-        */
+        :  null
       );
     },
   );

--- a/client/src/arcplanner/lib/src/ui/add_arc_screen.dart
+++ b/client/src/arcplanner/lib/src/ui/add_arc_screen.dart
@@ -33,8 +33,8 @@ class AddArcScreen extends StatelessWidget {
                   parentField(),
                   Flexible(
                     child: Container(
-                      width:MediaQuery.of(context).size.width * 0.4 , 
-                      child: arcList(),
+                      width:MediaQuery.of(context).size.width * 0.25 , 
+                      child: selectParent(),
                     ),
                   ),   
                 ]
@@ -134,42 +134,6 @@ Widget descriptionField(){
     );
  }
 
-Widget arcList() {
-  
-String _arcTitle;
-
-  return StreamBuilder(
-    stream: bloc.arcViewStream,
-    builder: (context, snapshot) {
-      return new FutureBuilder(
-        future: snapshot.data,
-        builder: (context, AsyncSnapshot<dynamic> snapshot) {
-          if (snapshot.hasData) {
-          dynamic snapshotData = snapshot.data;
-          return DropdownButton<dynamic>(
-            value: _arcTitle,
-            onChanged: (value) {
-              bloc.changeParent(value);
-              print("$value");
-            },
-            isExpanded: true,
-            items: List<DropdownMenuItem<dynamic>>.generate(
-            snapshotData.length,
-              (int index) => DropdownMenuItem<dynamic>(
-                value: snapshotData[index],
-                child: Text(snapshotData[index].title),
-              ),
-            ),
-          );
-           } else {
-            return Text('There are no Arcs/Tasks');
-          }   
-        },
-      );
-    },
-  );
-}
-
 Widget arcTile(Arc arc, BuildContext context) {
   var description = arc.description;
   if (description == null) {
@@ -190,6 +154,17 @@ Widget arcTile(Arc arc, BuildContext context) {
     child: ListTile(
       title: Text(arc.title),
     ),
+  );
+}
+
+Widget selectParent(){
+  return RaisedButton(
+    child: Text('Select'),
+    color: Colors.blue,
+    textColor: Colors.white,
+    onPressed: (){
+    //TODO add call to new select_arc_screen
+   },
   );
 }
 

--- a/client/src/arcplanner/lib/src/ui/arc_view_screen.dart
+++ b/client/src/arcplanner/lib/src/ui/arc_view_screen.dart
@@ -63,7 +63,7 @@ class ArcViewScreen extends StatelessWidget {
               textColor: Colors.blue,
               // Needs to open New Arc dialog
               onPressed: () {
-                Navigator.popAndPushNamed(context, '/addarc'); 
+               // Navigator.popAndPushNamed(context, '/addarc'); 
               },
             ),
           ],

--- a/client/src/arcplanner/lib/src/ui/arc_view_screen.dart
+++ b/client/src/arcplanner/lib/src/ui/arc_view_screen.dart
@@ -62,7 +62,9 @@ class ArcViewScreen extends StatelessWidget {
               color: Colors.white,
               textColor: Colors.blue,
               // Needs to open New Arc dialog
-              onPressed: () {},
+              onPressed: () {
+                Navigator.popAndPushNamed(context, '/addarc'); 
+              },
             ),
           ],
         ),

--- a/client/src/arcplanner/lib/src/ui/drawer_menu.dart
+++ b/client/src/arcplanner/lib/src/ui/drawer_menu.dart
@@ -62,7 +62,7 @@ Drawer drawerMenu(BuildContext context) {
               ),
           ),
           onTap: () {
-            Navigator.pop(context);
+            Navigator.popAndPushNamed(context, '/addarc');       
           },
         ),
         ListTile(

--- a/client/src/arcplanner/pubspec.yaml
+++ b/client/src/arcplanner/pubspec.yaml
@@ -24,6 +24,9 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^0.1.2
+  
+  rxdart: ^0.18.0
+
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This PR adds the arc view screen to the project in the file `add_arc_screen.dart` .This screen will allow for users to enter a new arc, as per the issue #15. This PR only adds the UI and the ability to add arcs has not yet been implemented. 

Upon review, note that this screen:
- Will allow a user to select a parent `Arc` but this will need to be modified to allow the removal of the parent `Arc` once selected (if needed)
- Should display what `Arcs` are be a parent of the `Arc` selected (and that the selection is a sub arc) This is to conform with the `Location` field in the [UI design template](https://github.com/smacademic/project-cgkm/wiki/ArcPlanner-UI-Design-Template)
- Is not displayed as a splash screen over the screen called from because it can be called from the side menu bar
- Requires changes to the Arc class to conform to the [UI design template](https://github.com/smacademic/project-cgkm/wiki/ArcPlanner-UI-Design-Template), or the template should be modified: 
Location is in the UI design template but has been replaced with the parent field (can be changed back)
EndDate is in the UI design template and should be added to the `Arc` class

I have noted that the file may need to be renamed `create_arc_screen.dart` for clarity.