### PR TITLE
Add Task View

### DIFF
--- a/client/src/arcplanner/lib/src/arcplanner.dart
+++ b/client/src/arcplanner/lib/src/arcplanner.dart
@@ -5,6 +5,7 @@ import 'ui/about_screen.dart';
 import 'ui/home_screen.dart';
 import 'ui/settings_screen.dart';
 import 'ui/arc_view_screen.dart';
+import 'ui/task_view_screen.dart';
 
 /// Observer for tracking page changes
 final RouteObserver<PageRoute> routeObserver = RouteObserver<PageRoute>();
@@ -16,6 +17,7 @@ class ArcPlanner extends StatelessWidget {
   static HomeScreen homeScreen = HomeScreen();
   static SettingsScreen settingsScreen = SettingsScreen();
   static ArcViewScreen arcViewScreen = ArcViewScreen();
+  static TaskViewScreen taskViewScreen = TaskViewScreen();
 
   Widget build(BuildContext context) {
     return MaterialApp(
@@ -32,6 +34,7 @@ class ArcPlanner extends StatelessWidget {
         '/home': (BuildContext context) => homeScreen,
         '/settings': (BuildContext context) => settingsScreen,
         '/arcview': (BuildContext context) => arcViewScreen,
+        '/taskview': (BuildContext context) => taskViewScreen
       },
       navigatorObservers: [routeObserver],
     );

--- a/client/src/arcplanner/lib/src/arcplanner.dart
+++ b/client/src/arcplanner/lib/src/arcplanner.dart
@@ -38,7 +38,7 @@ class ArcPlanner extends StatelessWidget {
         '/home': (BuildContext context) => homeScreen,
         '/settings': (BuildContext context) => settingsScreen,
         '/arcview': (BuildContext context) => arcViewScreen,
-        '/taskview': (BuildContext context) => taskViewScreen
+        '/taskview': (BuildContext context) => taskViewScreen,
         '/addarc': (BuildContext context) => addArcScreen,
       },
       navigatorObservers: [routeObserver],

--- a/client/src/arcplanner/lib/src/ui/task_view_screen.dart
+++ b/client/src/arcplanner/lib/src/ui/task_view_screen.dart
@@ -1,0 +1,114 @@
+import 'package:flutter/material.dart';
+import 'drawer_menu.dart';
+
+class TaskViewScreen extends StatelessWidget {
+  static String currentParent = "Home";
+
+  Widget build(context) {
+    return Scaffold(
+        body: ListView(
+          children: ListTile.divideTiles(context: context, tiles: [
+            arcPath(),
+            taskName(),
+            dateCreated(),
+            endDate(),
+            location(),
+            taskDescription(),
+          ]).toList(),
+        ),
+        drawer: drawerMenu(context),
+        bottomNavigationBar: BottomAppBar(
+            color: Colors.blue[400],
+            child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                children: <Widget>[
+                  RaisedButton(
+                    child: Text('Mark'),
+                    color: Colors.white,
+                    textColor: Colors.blue[400],
+                    onPressed: () {
+                      // implement here
+                      print('Mark tapped');
+                    },
+                  ),
+                  RaisedButton(
+                    child: Text('Edit'),
+                    color: Colors.white,
+                    textColor: Colors.blue[400],
+                    onPressed: () {
+                      // implement here
+                      print('Edit tapped');
+                    },
+                  ),
+                  RaisedButton(
+                    child: Text('Delete'),
+                    color: Colors.white,
+                    textColor: Colors.blue[400],
+                    onPressed: () {
+                      // implement here
+                      print('Delete tapped');
+                    },
+                  ),
+                ])),
+        floatingActionButton: FloatingActionButton(
+            backgroundColor: Colors.blue[400],
+            child: Icon(Icons.arrow_back),
+            onPressed: () {
+              Navigator.pop(context);
+            }));
+  }
+}
+
+Widget arcPath() {
+  return ListTile(
+      title: Text("Arc Path",
+          style: TextStyle(
+            fontSize: 16,
+          )),
+      onTap: () {});
+}
+
+Widget taskName() {
+  return ListTile(
+      title: Text("Task Name",
+          style: TextStyle(
+            fontSize: 20,
+          )),
+      onTap: () {});
+}
+
+Widget dateCreated() {
+  return ListTile(
+      title: Text("Date Created",
+          style: TextStyle(
+            fontSize: 20,
+          )),
+      onTap: () {});
+}
+
+Widget endDate() {
+  return ListTile(
+      title: Text("End Date",
+          style: TextStyle(
+            fontSize: 20,
+          )),
+      onTap: () {});
+}
+
+Widget location() {
+  return ListTile(
+      title: Text("Location",
+          style: TextStyle(
+            fontSize: 20,
+          )),
+      onTap: () {});
+}
+
+Widget taskDescription() {
+  return ListTile(
+      title: Text("Task Description",
+          style: TextStyle(
+            fontSize: 16,
+          )),
+      onTap: () {});
+}


### PR DESCRIPTION
This PR adds the UI only (without functionality) for the Task View Screen, as described in the [UI Design Template](https://github.com/smacademic/project-cgkm/wiki/ArcPlanner-UI-Design-Template#task-view).

This would be shown when tasks are selected from an Arc View. As tasks are not yet able to be shown, (in this branch, anyway), I viewed it by adding it to where "Archived Items" is in the drawer menu, as shown here:

```
 ListTile(
          title: Text(
            'Archived Items',
              style: TextStyle(
                fontSize: 20.0,
              ),
          ),
          onTap: () {
            // task view is here temporarily for test viewing only
            Navigator.popAndPushNamed(context, '/taskview');
          },
        ),
```

This particular change, as shown above, is not part of the PR to maintain the integrity of other parts of the app.