### PR TITLE
Add Calendar Screen UI

### DIFF
--- a/client/src/arcplanner/lib/main.dart
+++ b/client/src/arcplanner/lib/main.dart
@@ -13,9 +13,10 @@
 
 import 'package:flutter/material.dart';
 import 'src/arcplanner.dart';
+import 'package:intl/date_symbol_data_local.dart';
 
 void main() {
-  runApp(ArcPlanner());
+  initializeDateFormatting().then((_) => runApp(ArcPlanner()));
 }
 
 

--- a/client/src/arcplanner/lib/src/arcplanner.dart
+++ b/client/src/arcplanner/lib/src/arcplanner.dart
@@ -22,7 +22,7 @@ import 'ui/settings_screen.dart';
 import 'ui/arc_view_screen.dart';
 import 'ui/task_view_screen.dart';
 import 'ui/add_arc_screen.dart';
-
+import 'ui/calendar_screen.dart';
 
 /// Observer for tracking page changes
 final RouteObserver<PageRoute> routeObserver = RouteObserver<PageRoute>();
@@ -36,6 +36,7 @@ class ArcPlanner extends StatelessWidget {
   static ArcViewScreen arcViewScreen = ArcViewScreen();
   static TaskViewScreen taskViewScreen = TaskViewScreen();
   static AddArcScreen addArcScreen = AddArcScreen();
+  static CalendarScreen calendarScreen = CalendarScreen();
 
 
   Widget build(BuildContext context) {
@@ -55,6 +56,7 @@ class ArcPlanner extends StatelessWidget {
         '/arcview': (BuildContext context) => arcViewScreen,
         '/taskview': (BuildContext context) => taskViewScreen,
         '/addarc': (BuildContext context) => addArcScreen,
+        '/calendar': (BuildContext context) => calendarScreen,
       },
       navigatorObservers: [routeObserver],
     );

--- a/client/src/arcplanner/lib/src/ui/calendar_screen.dart
+++ b/client/src/arcplanner/lib/src/ui/calendar_screen.dart
@@ -1,0 +1,215 @@
+/** 
+ *  Team CGKM - Matthew Chastain, Justin Grabowski, Kevin Kelly, Jonathan Middleton
+ *  CS298 Spring 2019 
+ *
+ *  Authors: 
+ *    Primary: Kevin Kelly
+ *    Contributors: 
+ * 
+ *  Provided as is. No warranties expressed or implied. Use at your own risk.
+ *
+ *  This file contains ArcPlanner's home screen which will be displayed on 
+ *  launch. The screen shows users a list of upcoming tasks along with a Task 
+ *  quick-add button.
+ */
+
+import 'package:flutter/material.dart';
+import 'package:table_calendar/table_calendar.dart';
+import 'package:date_utils/date_utils.dart';
+import 'drawer_menu.dart';
+
+class CalendarScreen extends StatefulWidget {
+  @override
+  _CalendarScreen createState() => _CalendarScreen();
+}
+
+class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixin { 
+
+  DateTime _selectedDay;
+  Map<DateTime, List> _events;
+  Map<DateTime, List> _visibleEvents;
+  List _selectedEvents;
+  AnimationController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _selectedDay = DateTime.now();
+    _events = {
+      _selectedDay.subtract(Duration(days: 30)): ['Event A0', 'Event B0', 'Event C0'],
+      _selectedDay.subtract(Duration(days: 27)): ['Event A1'],
+      _selectedDay.subtract(Duration(days: 20)): ['Event A2', 'Event B2', 'Event C2', 'Event D2'],
+      _selectedDay.subtract(Duration(days: 16)): ['Event A3', 'Event B3'],
+      _selectedDay.subtract(Duration(days: 10)): ['Event A4', 'Event B4', 'Event C4'],
+      _selectedDay.subtract(Duration(days: 4)): ['Event A5', 'Event B5', 'Event C5'],
+      _selectedDay.subtract(Duration(days: 2)): ['Event A6', 'Event B6'],
+      _selectedDay: ['Event A7', 'Event B7', 'Event C7', 'Event D7'],
+      _selectedDay.add(Duration(days: 1)): ['Event A8', 'Event B8', 'Event C8', 'Event D8'],
+      _selectedDay.add(Duration(days: 3)): Set.from(['Event A9', 'Event A9', 'Event B9']).toList(),
+      _selectedDay.add(Duration(days: 7)): ['Event A10', 'Event B10', 'Event C10'],
+      _selectedDay.add(Duration(days: 11)): ['Event A11', 'Event B11'],
+      _selectedDay.add(Duration(days: 17)): ['Event A12', 'Event B12', 'Event C12', 'Event D12'],
+      _selectedDay.add(Duration(days: 22)): ['Event A13', 'Event B13'],
+      _selectedDay.add(Duration(days: 26)): ['Event A14', 'Event B14', 'Event C14'],
+    };
+
+    _selectedEvents = _events[_selectedDay] ?? [];
+    _visibleEvents = _events;
+
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 400),
+    );
+
+    _controller.forward();
+  }
+
+  void _onDaySelected(DateTime day, List events) {
+    setState(() {
+      _selectedDay = day;
+      _selectedEvents = events;
+    });
+  }
+
+  void _onVisibleDaysChanged(DateTime first, DateTime last, CalendarFormat format) {
+    setState(() {
+      _visibleEvents = Map.fromEntries(
+        _events.entries.where(
+          (entry) =>
+              entry.key.isAfter(first.subtract(const Duration(days: 1))) &&
+              entry.key.isBefore(last.add(const Duration(days: 1))),
+        ),
+      );
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text("Calendar"),
+      ),
+      
+      body: Column(
+        mainAxisSize: MainAxisSize.max,
+        children: <Widget>[
+          // Switch out 2 lines below to play with TableCalendar's settings
+          //-----------------------
+          _buildTableCalendarWithBuilders(),
+          const SizedBox(height: 8.0),
+          Expanded(child: _buildEventList()),
+        ],
+      ),
+      
+      drawer: drawerMenu(context)
+    );
+  }
+
+  // More advanced TableCalendar configuration (using Builders & Styles)
+  Widget _buildTableCalendarWithBuilders() {
+    return TableCalendar(
+      locale: 'en_US',
+      events: _visibleEvents,
+      initialCalendarFormat: CalendarFormat.month,
+      formatAnimation: FormatAnimation.slide,
+      startingDayOfWeek: StartingDayOfWeek.sunday,
+      availableGestures: AvailableGestures.all,
+      availableCalendarFormats: const {
+        CalendarFormat.month: '',
+        CalendarFormat.week: '',
+      },
+      calendarStyle: CalendarStyle(
+        outsideDaysVisible: false,
+        weekendStyle: TextStyle().copyWith(color: Colors.blue[800]),
+        outsideWeekendStyle: TextStyle().copyWith(color: Colors.blue[800]),
+      ),
+      daysOfWeekStyle: DaysOfWeekStyle(
+        weekendStyle: TextStyle().copyWith(color: Colors.blue[800]),
+      ),
+      headerStyle: HeaderStyle(
+        centerHeaderTitle: true,
+        formatButtonVisible: false,
+      ),
+      builders: CalendarBuilders(
+        selectedDayBuilder: (context, date, _) {
+          return FadeTransition(
+            opacity: Tween(begin: 0.0, end: 1.0).animate(_controller),
+            child: Container(
+              margin: const EdgeInsets.all(4.0),
+              padding: const EdgeInsets.only(top: 5.0, left: 6.0),
+              color: Colors.red[200],
+              width: 100,
+              height: 100,
+              child: Text(
+                '${date.day}',
+                style: TextStyle().copyWith(fontSize: 16.0),
+              ),
+            ),
+          );
+        },
+        todayDayBuilder: (context, date, _) {
+          return Container(
+            margin: const EdgeInsets.all(4.0),
+            padding: const EdgeInsets.only(top: 5.0, left: 6.0),
+            color: Colors.green[300],
+            width: 100,
+            height: 100,
+            child: Text(
+              '${date.day}',
+              style: TextStyle().copyWith(fontSize: 16.0),
+            ),
+          );
+        },
+        markersBuilder: (context, date, events) {
+          return Positioned(
+            right: 1,
+            bottom: 1,
+            child: AnimatedContainer(
+              duration: const Duration(milliseconds: 400),
+              decoration: BoxDecoration(
+                shape: BoxShape.rectangle,
+                color: Utils.isSameDay(date, _selectedDay)
+                    ? Colors.deepOrange
+                    : Utils.isSameDay(date, DateTime.now()) ? Colors.deepOrange : Colors.blue[400],
+              ),
+              width: 16.0,
+              height: 16.0,
+              child: Center(
+                child: Text(
+                  '${events.length}',
+                  style: TextStyle().copyWith(
+                    color: Colors.white,
+                    fontSize: 12.0,
+                  ),
+                ),
+              ),
+            ),
+          );
+        },
+      ),
+      onDaySelected: (date, events) {
+        _onDaySelected(date, events);
+        _controller.forward(from: 0.0);
+      },
+      onVisibleDaysChanged: _onVisibleDaysChanged,
+    );
+  }
+
+  Widget _buildEventList() {
+    return ListView(
+      children: _selectedEvents
+          .map((event) => Container(
+                decoration: BoxDecoration(
+                  border: Border.all(width: 0.8),
+                  borderRadius: BorderRadius.circular(12.0),
+                ),
+                margin: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 4.0),
+                child: ListTile(
+                  title: Text(event.toString()),
+                  onTap: () => print('$event tapped!'),
+                ),
+              ))
+          .toList(),
+    );
+  }
+}

--- a/client/src/arcplanner/lib/src/ui/drawer_menu.dart
+++ b/client/src/arcplanner/lib/src/ui/drawer_menu.dart
@@ -81,13 +81,13 @@ Drawer drawerMenu(BuildContext context) {
         ),
         ListTile(
           title: Text(
-            'Calendar View',
+            'Calendar',
               style: TextStyle(
                 fontSize: 20.0,
               ),
           ),
           onTap: () {
-            Navigator.pop(context);
+            Navigator.popAndPushNamed(context, '/calendar');
           },
         ),
         ListTile(

--- a/client/src/arcplanner/pubspec.yaml
+++ b/client/src/arcplanner/pubspec.yaml
@@ -19,6 +19,8 @@ dependencies:
   sqflite: ^1.1.3
   uuid: 2.0.0
   auto_size_text: ^1.1.1
+  table_calendar: ^1.1.4
+  intl: ^0.15.8
 
 
   # The following adds the Cupertino Icons font to your application.


### PR DESCRIPTION
This PR adds a calendar screen to the app. This PR is only for UI functionality and is not connected to the BLoC or Arcs/Task Objects at all.  

To add the calendar to the app I have imported the `table_calendar` package which requires the `intl` package in order to allow variation of calendar languages. While the variation of calendar languages is not needed now the ability to switch easily from this package will help a lot in the future when adding varying language options.

I have updated the drawer menu, so getting to the page is a simple as clicking on the calendar in the drawer. 

I am somewhat unsure about the coloring and format so I am very open to suggestions/comments about the styling. The package for the calendar is very flexible in terms of design.  

Much of the screen is taken and customized from the package example found [here](https://github.com/aleksanderwozniak/table_calendar/blob/master/example/lib/main.dart) as it matched what I was envisioning quite well and had a very good example "events" that will be replaced with Arcs/Tasks when the functionality is added. 

The package for the calendar is found [here](https://pub.dartlang.org/packages/table_calendar)
