### PR TITLE
Fix Missing Tasks from Screens after reload

### DIFF
--- a/client/src/arcplanner/lib/src/util/databaseHelper.dart
+++ b/client/src/arcplanner/lib/src/util/databaseHelper.dart
@@ -129,7 +129,7 @@ class DatabaseHelper {
               UNION
               SELECT TID As UUID
               FROM Task
-              WHERE Task.AID = Arc1.UID
+              WHERE Task.AID = Arc1.AID
           )
         ) As ChildrenUUIDs
         FROM Arc_t AS Arc1


### PR DESCRIPTION
This PR fixes the missing Task issue. The problem was that the view was referring to `UID` of parent rather then `AID` as it was supposed to. Tasks should always appear now but will require the database/app to be reinstalled. 

Closes #86 