### PR TITLE
Fix parent select screen

### DIFF
--- a/client/src/arcplanner/lib/src/blocs/bloc.dart
+++ b/client/src/arcplanner/lib/src/blocs/bloc.dart
@@ -230,11 +230,16 @@ class Bloc extends Object with Validators {
       db.insertArc(ar);
     }
 
+    initializeAddArcStreams();
+    
+  }
+
+  // Reset the streams used by the add arc screen
+  initializeAddArcStreams() {
     bloc.changeTitle(null);
     bloc.changeEndDate(null);
     bloc.changeDescription(null);
     bloc.changeParent(null);
-    
   }
 
   // Closes the stream controller

--- a/client/src/arcplanner/lib/src/blocs/bloc.dart
+++ b/client/src/arcplanner/lib/src/blocs/bloc.dart
@@ -78,6 +78,8 @@ class Bloc extends Object with Validators {
       return await data['object'];
     } else if (data['flag'] == "getChildren") {
       return await getChildren(data['object']);
+    } else if (data['flag'] == "getChildArcs") {
+      return await getChildArcs(data['object']);
     } else if (data['flag'] == "backButton") {
       Arc parent = getFromMap(data['object']);
       return await getChildren(parent.parentArc);
@@ -171,6 +173,42 @@ class Bloc extends Object with Validators {
     }
     return children;
   }
+
+ // Checks to see if children are in map. If they exist in map then send them
+  //  back via stream. Otherwise load them from database and into map. Then
+  //  to the UI via stream
+  Future<List<dynamic>> getChildArcs (String parentUUID) async {
+    List<dynamic> children = new List();
+
+
+    // If there is no supplied UUID supply parentArc = null, the masterArcs
+    if (parentUUID == null) {
+      children = insertListIntoMap(await db.getMasterArcs());
+      return children;
+    }
+
+    Arc parent = getFromMap(parentUUID);
+    
+    // If childrenUUIDs is empty then it has no children
+    if (parent.childrenUUIDs?.isEmpty ?? true) { // Key does not exist in map yet or doesn't have children
+      return null;
+    } else {
+      // If Children exist in map already
+      for (String uuid in parent.childrenUUIDs) {
+        if (checkMap(uuid)) {
+          children.add(getFromMap(uuid));
+        }    
+        else {
+          // If one child UUID is missing use query to get all children and
+          //  add to map. This is to avoid many queries if large list of children
+          children = insertListIntoMap(await db.getChildArcs(parentUUID));
+          break;
+        }          
+      }
+    }
+    return children;
+  }
+
 
   submitArc() {
     final validArcTitle = _arcTitleFieldController.value;

--- a/client/src/arcplanner/lib/src/blocs/bloc.dart
+++ b/client/src/arcplanner/lib/src/blocs/bloc.dart
@@ -31,6 +31,9 @@ class Bloc extends Object with Validators {
   // Create stream and getters for views to interact with
   final _arcViewController = StreamController<dynamic>.broadcast();
 
+  // Create stream and getters for parent)sdelection view
+  final _arcParentSelectViewController = StreamController<dynamic>.broadcast();
+
   // Streams for add_arc_screen
   final _arcTitleFieldController = BehaviorSubject<String>();
   final _arcEndDateFieldController = BehaviorSubject<String>();
@@ -38,6 +41,8 @@ class Bloc extends Object with Validators {
   final _arcParentFieldController = BehaviorSubject<Arc>();
   
   Stream<dynamic> get arcViewStream => _arcViewController.stream.map(transformData);
+
+  Stream<dynamic> get arcParentSelectViewStream => _arcParentSelectViewController.stream.map(transformData);
 
   // Add data to streams for Add Arc Screen
   Stream<String> get arcTitleFieldStream => _arcTitleFieldController.stream; //.transform(validateTitle);
@@ -61,6 +66,10 @@ class Bloc extends Object with Validators {
   void arcViewInsert(dynamic obj) {
     _arcViewController.sink.add(obj);
   } 
+
+  void parentSelectInsert(dynamic obj) {
+    _arcParentSelectViewController.sink.add(obj);
+  }
 
   // Map function that based on the given flag from stream will perform
   //  varying operations that return needed arcs to stream 
@@ -193,6 +202,7 @@ class Bloc extends Object with Validators {
   // Closes the stream controller
   dispose() {
     _arcViewController.close();
+    _arcParentSelectViewController.close();
 
     // Close Add Arc Screen streams
     _arcDescriptionFieldController.close();

--- a/client/src/arcplanner/lib/src/ui/add_arc_screen.dart
+++ b/client/src/arcplanner/lib/src/ui/add_arc_screen.dart
@@ -23,10 +23,11 @@ class AddArcScreen extends StatelessWidget {
   
   Widget build(context) {
 
-    return Scaffold(
-      appBar: AppBar(
-        actions: <Widget>[
-          IconButton(
+    return WillPopScope(
+    onWillPop: () async => false,
+      child :Scaffold(
+        appBar: AppBar(
+          leading: IconButton(
             icon: Icon(Icons.cancel),
             onPressed: () {
               Navigator.pushNamedAndRemoveUntil(context, '/home', (Route<dynamic> route) => false);
@@ -34,47 +35,47 @@ class AddArcScreen extends StatelessWidget {
               bloc.initializeAddArcStreams();
             },
           )
-        ],
-      ),
-      
-      body: Container(
-        margin: EdgeInsets.only(left: 10.0, right: 10.0),
-        child: ListView(
-          children:[
-            Container(margin: EdgeInsets.only(top: 15)),
-            titleField(),
-            dueDate(),
-            descriptionField(),
-            Container(
-              margin: EdgeInsets.only(top: 20),
-              child: Row( 
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children:[ 
-                  parentField(),
-                  Flexible(
-                    child: Container(
-                      width:MediaQuery.of(context).size.width * 0.25 , 
-                      child: selectParent(context),
-                    ),
-                  ),   
-                ]
+        ),
+        
+        body: Container(
+          margin: EdgeInsets.only(left: 10.0, right: 10.0),
+          child: ListView(
+            children:[
+              Container(margin: EdgeInsets.only(top: 15)),
+              titleField(),
+              dueDate(),
+              descriptionField(),
+              Container(
+                margin: EdgeInsets.only(top: 20),
+                child: Row( 
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children:[ 
+                    parentField(),
+                    Flexible(
+                      child: Container(
+                        width:MediaQuery.of(context).size.width * 0.25 , 
+                        child: selectParent(context),
+                      ),
+                    ),   
+                  ]
+                ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
-      ),
 
-      drawer: drawerMenu(context),
+        //drawer: drawerMenu(context),
 
-      bottomNavigationBar: BottomAppBar(
-        color: Colors.blue,
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-          children: <Widget>[
-            submitArc(),
-          ],
+        bottomNavigationBar: BottomAppBar(
+          color: Colors.blue,
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+            children: <Widget>[
+              submitArc(),
+            ],
+          ),
         ),
-      ),
+      )
     );
   }
 }

--- a/client/src/arcplanner/lib/src/ui/add_arc_screen.dart
+++ b/client/src/arcplanner/lib/src/ui/add_arc_screen.dart
@@ -99,29 +99,6 @@ class AddArcScreen extends StatelessWidget {
   );
 }
 
-// Widget dueDate(){
-//   return StreamBuilder(
-//     stream: bloc.arcEndDateFieldStream,
-//     builder: (context, snapshot) {
-//       return DateTimePickerFormField(
-//         inputType: InputType.date,
-//         format: DateFormat.yMEd(),
-//         editable: false,
-//         decoration: InputDecoration(
-//           hintText: snapshot.hasData ? 
-//           DateFormat.yMEd().format(DateTime.parse(snapshot.data))
-//           : 'Due Date',
-//           hintStyle: TextStyle(
-//             color: Colors.black,
-//             fontSize: 16
-//           )
-//         ),
-//         onChanged: (date) => bloc.changeEndDate(date.toString()),
-//       );
-//     }
-//   );
-// }
-
 Widget dueDate(){
   return StreamBuilder(
     stream: bloc.arcEndDateFieldStream,

--- a/client/src/arcplanner/lib/src/ui/add_arc_screen.dart
+++ b/client/src/arcplanner/lib/src/ui/add_arc_screen.dart
@@ -30,6 +30,8 @@ class AddArcScreen extends StatelessWidget {
             icon: Icon(Icons.cancel),
             onPressed: () {
               Navigator.pushNamedAndRemoveUntil(context, '/home', (Route<dynamic> route) => false);
+              // Empty the stream
+              bloc.initializeAddArcStreams();
             },
           )
         ],

--- a/client/src/arcplanner/lib/src/ui/add_arc_screen.dart
+++ b/client/src/arcplanner/lib/src/ui/add_arc_screen.dart
@@ -87,6 +87,10 @@ class AddArcScreen extends StatelessWidget {
         decoration: InputDecoration(
           hintText: snapshot.hasData? snapshot.data: 'Title',
           errorText: snapshot.error,
+           hintStyle: TextStyle(
+            fontSize: 16,
+            color: Colors.black
+          ),
         ),
       );
     }
@@ -102,7 +106,11 @@ Widget dueDate(){
         format: DateFormat.yMEd(),
         editable: false,
         decoration: InputDecoration(
-          labelText: 'Due Date',
+          hintText: snapshot.hasData ? DateFormat.yMEd().format(DateTime.parse(snapshot.data)): 'Due Date',
+          hintStyle: TextStyle(
+            color: Colors.black,
+            fontSize: 16
+          )
         ),
         onChanged: (date) => bloc.changeEndDate(date.toString()),
       );
@@ -122,6 +130,10 @@ Widget descriptionField(){
         decoration: InputDecoration(
           hintText: snapshot.hasData? snapshot.data:'Description',
           errorText: snapshot.error,
+          hintStyle: TextStyle(
+            fontSize: 16,
+            color: Colors.black
+          ),
         ),
       );
     }
@@ -130,13 +142,17 @@ Widget descriptionField(){
 
  Widget parentField(){
   return StreamBuilder(
-      stream: bloc.arcParentFieldStream,
-      builder: (context, snapshot) {
-        return Text(
-          snapshot.hasData? snapshot.data.title : "Parent",
-        );
-      }
-    );
+    stream: bloc.arcParentFieldStream,
+    builder: (context, snapshot) {
+      return Text(
+        snapshot.hasData? snapshot.data.title : "Parent",
+        style: TextStyle(
+          fontSize: 16,
+          color: Colors.black
+        ),
+      );
+    }
+  );
  }
 
 Widget selectParent(BuildContext context){
@@ -146,7 +162,6 @@ Widget selectParent(BuildContext context){
     textColor: Colors.white,
     onPressed: () {
       _openParentSelectDialog(context);
-     // Navigator.popAndPushNamed(context, '/parent');   },
     }
   );
 }
@@ -160,9 +175,8 @@ Widget submitArc() {
         color: Colors.white,
         textColor: Colors.blue,
         onPressed: snapshot.hasData ? () { 
-          bloc.submitArc(); //Currently just returns to previous screen
+          bloc.submitArc(); 
           Navigator.pushNamedAndRemoveUntil(context, '/home', (Route<dynamic> route) => false);
-          //bloc.changeTitle(null);
           }
         : null
       );

--- a/client/src/arcplanner/lib/src/ui/add_arc_screen.dart
+++ b/client/src/arcplanner/lib/src/ui/add_arc_screen.dart
@@ -87,7 +87,7 @@ class AddArcScreen extends StatelessWidget {
         onChanged: bloc.changeTitle,
         keyboardType: TextInputType.text,
         decoration: InputDecoration(
-          hintText: snapshot.hasData? snapshot.data: 'Title',
+          hintText: 'Title',
           errorText: snapshot.error,
            hintStyle: TextStyle(
             fontSize: 16,
@@ -99,24 +99,46 @@ class AddArcScreen extends StatelessWidget {
   );
 }
 
+// Widget dueDate(){
+//   return StreamBuilder(
+//     stream: bloc.arcEndDateFieldStream,
+//     builder: (context, snapshot) {
+//       return DateTimePickerFormField(
+//         inputType: InputType.date,
+//         format: DateFormat.yMEd(),
+//         editable: false,
+//         decoration: InputDecoration(
+//           hintText: snapshot.hasData ? 
+//           DateFormat.yMEd().format(DateTime.parse(snapshot.data))
+//           : 'Due Date',
+//           hintStyle: TextStyle(
+//             color: Colors.black,
+//             fontSize: 16
+//           )
+//         ),
+//         onChanged: (date) => bloc.changeEndDate(date.toString()),
+//       );
+//     }
+//   );
+// }
+
 Widget dueDate(){
   return StreamBuilder(
     stream: bloc.arcEndDateFieldStream,
     builder: (context, snapshot) {
+
       return DateTimePickerFormField(
         inputType: InputType.date,
         format: DateFormat.yMEd(),
         editable: false,
         decoration: InputDecoration(
-          hintText: snapshot.hasData ? 
-          DateFormat.yMEd().format(DateTime.parse(snapshot.data))
-          : 'Due Date',
+          hintText: 'Due Date',
           hintStyle: TextStyle(
-            color: Colors.black,
-            fontSize: 16
-          )
+            fontSize: 16,
+            color: Colors.black
+          ),
         ),
-        onFieldSubmitted: (date) => bloc.changeEndDate(date.toString()),
+        onChanged: (date) => bloc.changeEndDate(date.toString()),
       );
     }
   );
@@ -132,7 +154,7 @@ Widget descriptionField(){
         keyboardType: TextInputType.multiline,
         textInputAction: TextInputAction.done,
         decoration: InputDecoration(
-          hintText: snapshot.hasData? snapshot.data:'Description',
+          hintText: 'Description',
           errorText: snapshot.error,
           hintStyle: TextStyle(
             fontSize: 16,
@@ -175,16 +197,10 @@ Widget submitArc() {
     stream: bloc.arcTitleFieldStream, 
     builder: (context, snapshot) {
       return FlatButton.icon(
+        disabledTextColor: Colors.grey,
         icon: Icon(Icons.library_add, color: Colors.white,),
-        label: Text (
-          'Submit',
-          style: TextStyle(
-            color: Colors.white,
-            fontSize: 18
-          ),
-        ),
+        label: Text ('Submit'),
         textColor: Colors.white,
-        //textColor: Colors.blue,
         onPressed: snapshot.hasData ? () { 
           bloc.submitArc(); 
           Navigator.pushNamedAndRemoveUntil(context, '/home', (Route<dynamic> route) => false);

--- a/client/src/arcplanner/lib/src/ui/add_arc_screen.dart
+++ b/client/src/arcplanner/lib/src/ui/add_arc_screen.dart
@@ -15,6 +15,7 @@
 import 'package:flutter/material.dart';
 import '../blocs/bloc.dart';
 import 'drawer_menu.dart';
+import 'parent_select_screen.dart';
 import 'package:intl/intl.dart';
 import 'package:datetime_picker_formfield/datetime_picker_formfield.dart';
 
@@ -144,7 +145,9 @@ Widget selectParent(BuildContext context){
     color: Colors.blue,
     textColor: Colors.white,
     onPressed: () {
-      Navigator.popAndPushNamed(context, '/parent');   },
+      _openParentSelectDialog(context);
+     // Navigator.popAndPushNamed(context, '/parent');   },
+    }
   );
 }
 
@@ -164,5 +167,16 @@ Widget submitArc() {
         : null
       );
     },
+  );
+}
+
+void _openParentSelectDialog(BuildContext context) {
+  Navigator.of(context).push(
+    new MaterialPageRoute<Null>(
+      builder: (BuildContext context) {
+        return new ParentSelectScreen();
+      },
+      fullscreenDialog: true
+    )
   );
 }

--- a/client/src/arcplanner/lib/src/ui/add_arc_screen.dart
+++ b/client/src/arcplanner/lib/src/ui/add_arc_screen.dart
@@ -172,10 +172,17 @@ Widget submitArc() {
   return StreamBuilder(
     stream: bloc.arcTitleFieldStream, 
     builder: (context, snapshot) {
-      return RaisedButton(
-        child: Text('Submit'),
-        color: Colors.white,
-        textColor: Colors.blue,
+      return FlatButton.icon(
+        icon: Icon(Icons.library_add, color: Colors.white,),
+        label: Text (
+          'Submit',
+          style: TextStyle(
+            color: Colors.white,
+            fontSize: 18
+          ),
+        ),
+        textColor: Colors.white,
+        //textColor: Colors.blue,
         onPressed: snapshot.hasData ? () { 
           bloc.submitArc(); 
           Navigator.pushNamedAndRemoveUntil(context, '/home', (Route<dynamic> route) => false);

--- a/client/src/arcplanner/lib/src/ui/add_arc_screen.dart
+++ b/client/src/arcplanner/lib/src/ui/add_arc_screen.dart
@@ -108,13 +108,15 @@ Widget dueDate(){
         format: DateFormat.yMEd(),
         editable: false,
         decoration: InputDecoration(
-          hintText: snapshot.hasData ? DateFormat.yMEd().format(DateTime.parse(snapshot.data)): 'Due Date',
+          hintText: snapshot.hasData ? 
+          DateFormat.yMEd().format(DateTime.parse(snapshot.data))
+          : 'Due Date',
           hintStyle: TextStyle(
             color: Colors.black,
             fontSize: 16
           )
         ),
-        onChanged: (date) => bloc.changeEndDate(date.toString()),
+        onFieldSubmitted: (date) => bloc.changeEndDate(date.toString()),
       );
     }
   );

--- a/client/src/arcplanner/lib/src/ui/parent_arc_tile.dart
+++ b/client/src/arcplanner/lib/src/ui/parent_arc_tile.dart
@@ -135,9 +135,9 @@ Widget parentArcTile(Arc arc, BuildContext context) {
         //If going to a screen that shows no children then set flag to true
         if (arc.childrenUUIDs?.isEmpty ?? true) {
           ArcViewScreen.atNoArcTaskScreen = true;
-          bloc.arcViewInsert({ 'object' : null, 'flag': 'clear'});
+          bloc.parentSelectInsert({ 'object' : null, 'flag': 'clear'});
         } else {
-          bloc.arcViewInsert({ 'object' : arc.aid, 'flag': 'getChildren'});
+          bloc.parentSelectInsert({ 'object' : arc.aid, 'flag': 'getChildArcs'});
         }
       } 
       //onLongPress: ,

--- a/client/src/arcplanner/lib/src/ui/parent_arc_tile.dart
+++ b/client/src/arcplanner/lib/src/ui/parent_arc_tile.dart
@@ -121,7 +121,7 @@ Widget parentArcTile(Arc arc, BuildContext context) {
                     textColor: Colors.white,
                     onPressed: () {
                       bloc.changeParent(arc);
-                      Navigator.pushNamedAndRemoveUntil(context, '/addarc', (Route<dynamic> route) => false);   
+                      Navigator.of(context).pop();  
                       //TODO add call to new select_arc_screen
                       },
                   ),

--- a/client/src/arcplanner/lib/src/ui/parent_arc_tile.dart
+++ b/client/src/arcplanner/lib/src/ui/parent_arc_tile.dart
@@ -18,14 +18,14 @@ import '../model/arc.dart';
 import 'package:auto_size_text/auto_size_text.dart';
 import 'arc_view_screen.dart';
 import 'package:intl/intl.dart';
-import 'add_arc_screen.dart';
+import 'parent_select_screen.dart';
 
 
 Widget parentArcTile(Arc arc, BuildContext context) {
   
   var description = arc.description;
 
-  ArcViewScreen.currentParent = arc.parentArc;
+  ParentSelectScreen.currentParent = arc.parentArc;
 
   if (description == null) {
     description = '';

--- a/client/src/arcplanner/lib/src/ui/parent_select_screen.dart
+++ b/client/src/arcplanner/lib/src/ui/parent_select_screen.dart
@@ -93,7 +93,7 @@ class ParentSelectScreen extends StatelessWidget {
                    Navigator.of(context).pop();
                 } else {
                   if (atNoArcTaskScreen) {
-                    bloc.parentSelectInsert({ 'object' : currentParent, 'flag': 'getChildren'});
+                    bloc.parentSelectInsert({ 'object' : currentParent, 'flag': 'getChildArcs'});
                     atNoArcTaskScreen = false;
                   } 
                   else

--- a/client/src/arcplanner/lib/src/ui/parent_select_screen.dart
+++ b/client/src/arcplanner/lib/src/ui/parent_select_screen.dart
@@ -23,12 +23,8 @@ class ParentSelectScreen extends StatelessWidget {
   static String currentParent = "Home";
   static bool atNoArcTaskScreen = false;
 
-  _toTaskView(Task task) {
-  }
-
   Widget build(context) {
     bool firstTimeLoading = true;
-
 
     return Scaffold(
       backgroundColor: Colors.white,
@@ -54,13 +50,13 @@ class ParentSelectScreen extends StatelessWidget {
         children: <Widget>[
           Expanded(
             child: StreamBuilder(
-              stream: bloc.arcViewStream,
+              stream: bloc.arcParentSelectViewStream,
               builder: (context, snapshot) {
                 return new FutureBuilder(
                   future: snapshot.data,
                   builder: (context, snapshot) {
                     if (firstTimeLoading) {
-                      bloc.arcViewInsert({ 'object' : null, 'flag': 'getChildren'});
+                      bloc.parentSelectInsert({ 'object' : null, 'flag': 'getChildren'});
                       firstTimeLoading = false;
                     }
                     
@@ -85,30 +81,6 @@ class ParentSelectScreen extends StatelessWidget {
 
       drawer: drawerMenu(context),
 
-      // bottomNavigationBar: BottomAppBar(
-      //   color: Colors.blue[400],
-      //   child: Row(
-      //     mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-      //     children: <Widget>[
-      //       RaisedButton(
-      //         child: Text('New Task'),
-      //         color: Colors.white,
-      //         textColor: Colors.blue[400],
-      //         // Needs to open New Task dialog
-      //         onPressed: () {},
-      //       ),
-      //       RaisedButton(
-      //         child: Text('New Arc'),
-      //         color: Colors.white,
-      //         textColor: Colors.blue[400],
-      //         // Needs to open New Arc dialog
-      //         onPressed: () {
-      //          // Navigator.popAndPushNamed(context, '/addarc'); 
-      //         },
-      //       ),
-      //     ],
-      //   ),
-      // ),
       bottomNavigationBar: BottomAppBar(
         color: Colors.blue[400],
         child: Row(
@@ -118,14 +90,14 @@ class ParentSelectScreen extends StatelessWidget {
               icon: Icon(Icons.arrow_back),
               onPressed: () {
                if (currentParent == null && !atNoArcTaskScreen) {
-                  Navigator.pop(context);
+                   Navigator.of(context).pop();
                 } else {
                   if (atNoArcTaskScreen) {
-                    bloc.arcViewInsert({ 'object' : currentParent, 'flag': 'getChildren'});
+                    bloc.parentSelectInsert({ 'object' : currentParent, 'flag': 'getChildren'});
                     atNoArcTaskScreen = false;
                   } 
                   else
-                    bloc.arcViewInsert({ 'object' : currentParent, 'flag': 'backButton'});
+                    bloc.parentSelectInsert({ 'object' : currentParent, 'flag': 'backButton'});
                 }
               },
             )

--- a/client/src/arcplanner/lib/src/ui/parent_select_screen.dart
+++ b/client/src/arcplanner/lib/src/ui/parent_select_screen.dart
@@ -33,6 +33,23 @@ class ParentSelectScreen extends StatelessWidget {
     return Scaffold(
       backgroundColor: Colors.white,
 
+      appBar: AppBar(
+        backgroundColor: Colors.blue[400],
+        title: Text(
+          'Select Parent Arc',
+          textAlign: TextAlign.center,
+        ),
+        centerTitle: true,
+        actions: <Widget>[
+          IconButton(
+            icon: Icon(Icons.cancel),
+            onPressed: () {
+              Navigator.of(context).pop();
+            },
+          )
+        ],
+      ),
+
       body: Column(
         children: <Widget>[
           Expanded(
@@ -68,46 +85,52 @@ class ParentSelectScreen extends StatelessWidget {
 
       drawer: drawerMenu(context),
 
+      // bottomNavigationBar: BottomAppBar(
+      //   color: Colors.blue[400],
+      //   child: Row(
+      //     mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+      //     children: <Widget>[
+      //       RaisedButton(
+      //         child: Text('New Task'),
+      //         color: Colors.white,
+      //         textColor: Colors.blue[400],
+      //         // Needs to open New Task dialog
+      //         onPressed: () {},
+      //       ),
+      //       RaisedButton(
+      //         child: Text('New Arc'),
+      //         color: Colors.white,
+      //         textColor: Colors.blue[400],
+      //         // Needs to open New Arc dialog
+      //         onPressed: () {
+      //          // Navigator.popAndPushNamed(context, '/addarc'); 
+      //         },
+      //       ),
+      //     ],
+      //   ),
+      // ),
       bottomNavigationBar: BottomAppBar(
         color: Colors.blue[400],
         child: Row(
-          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
           children: <Widget>[
-            RaisedButton(
-              child: Text('New Task'),
+            IconButton(
               color: Colors.white,
-              textColor: Colors.blue[400],
-              // Needs to open New Task dialog
-              onPressed: () {},
-            ),
-            RaisedButton(
-              child: Text('New Arc'),
-              color: Colors.white,
-              textColor: Colors.blue[400],
-              // Needs to open New Arc dialog
+              icon: Icon(Icons.arrow_back),
               onPressed: () {
-               // Navigator.popAndPushNamed(context, '/addarc'); 
+               if (currentParent == null && !atNoArcTaskScreen) {
+                  Navigator.pop(context);
+                } else {
+                  if (atNoArcTaskScreen) {
+                    bloc.arcViewInsert({ 'object' : currentParent, 'flag': 'getChildren'});
+                    atNoArcTaskScreen = false;
+                  } 
+                  else
+                    bloc.arcViewInsert({ 'object' : currentParent, 'flag': 'backButton'});
+                }
               },
-            ),
+            )
           ],
         ),
-      ),
-
-      floatingActionButton: FloatingActionButton(
-        backgroundColor: Colors.blue[400],
-        child: Icon(Icons.arrow_back),
-        onPressed: () {
-          if (currentParent == null && !atNoArcTaskScreen) {
-            Navigator.pop(context);
-          } else {
-            if (atNoArcTaskScreen) {
-              bloc.arcViewInsert({ 'object' : currentParent, 'flag': 'getChildren'});
-              atNoArcTaskScreen = false;
-            } 
-            else
-              bloc.arcViewInsert({ 'object' : currentParent, 'flag': 'backButton'});
-          }
-        },
       ),
     );
   }

--- a/client/src/arcplanner/lib/src/ui/parent_select_screen.dart
+++ b/client/src/arcplanner/lib/src/ui/parent_select_screen.dart
@@ -56,7 +56,7 @@ class ParentSelectScreen extends StatelessWidget {
                   future: snapshot.data,
                   builder: (context, snapshot) {
                     if (firstTimeLoading) {
-                      bloc.parentSelectInsert({ 'object' : null, 'flag': 'getChildren'});
+                      bloc.parentSelectInsert({ 'object' : null, 'flag': 'getChildArcs'});
                       firstTimeLoading = false;
                     }
                     

--- a/client/src/arcplanner/lib/src/util/databaseHelper.dart
+++ b/client/src/arcplanner/lib/src/util/databaseHelper.dart
@@ -196,6 +196,13 @@ class DatabaseHelper {
       
   }
 
+    // given a UUID, returns a list of mapped children
+  Future<List<Map>> getChildArcs(String uuid) async {
+    var dbClient = await db;
+    List<Map> arcList = await dbClient.rawQuery('SELECT * FROM Arc WHERE ParentArc = "$uuid"');
+    return arcList;
+  }
+
   // pulls all Arcs and Tasks out of the database and creates objects out of them
   Future<List<Map>> getArcList() async {
     var dbClient = await db;


### PR DESCRIPTION
This PR fixes known issues existing in the `add_arc_screen`
These issues include: 
- Inability to travel back up the parent arc tree using the back button in the `parent_select_screen`
- Utilization of streams belonging to the `arc_view_screen`
- Tasks shown in `parent_select_screen` when only arcs should be shown

Additional fixes: 
- Due Date field was not displaying its value is the user entered a due date, and then selected a parent arc (leaving the add arc screen and the returning upon the parent arc selection)
- UI updates for visual improvements
- Removal of unnecessary commented out code

Note: This PR will help in the development of the Add Task screen and will close issue #15
