### PR TITLE
Fix task tile layout

### DIFF
--- a/client/src/arcplanner/lib/src/ui/arc_tile.dart
+++ b/client/src/arcplanner/lib/src/ui/arc_tile.dart
@@ -48,10 +48,6 @@ Widget arcTile(Arc arc, BuildContext context) {
         mainAxisAlignment: MainAxisAlignment.start,
         children: <Widget>[
           Container(
-            padding: EdgeInsets.only(
-              //top: 10.0,
-              bottom: 10.0,
-            ),
             child: Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: <Widget>[
@@ -96,6 +92,7 @@ Widget arcTile(Arc arc, BuildContext context) {
           ),
           Container(
             padding: EdgeInsets.only(
+              top: 5.0,
               bottom: 10.0,
             ),
             child: AutoSizeText(description,

--- a/client/src/arcplanner/lib/src/ui/home_screen.dart
+++ b/client/src/arcplanner/lib/src/ui/home_screen.dart
@@ -21,6 +21,7 @@ import 'arc_tile.dart';
 import 'task_tile.dart';
 import '../model/arc.dart';
 import '../model/task.dart';
+import 'package:intl/intl.dart';
 
 class HomeScreen extends StatelessWidget {
   void _newTask() {}
@@ -31,6 +32,21 @@ class HomeScreen extends StatelessWidget {
 
     return Scaffold(
       backgroundColor: Colors.white,
+
+      appBar: AppBar(
+        title: Text("Today is " 
+          + DateFormat.MEd().format(DateTime.now()),
+          ),
+          centerTitle: true,
+          actions: <Widget>[
+            IconButton(
+              icon: Icon(Icons.add),
+              onPressed: () {
+                _newTask();
+              },
+            )
+          ],
+      ),
 
       body: SafeArea(
         child: Column(

--- a/client/src/arcplanner/lib/src/ui/home_screen.dart
+++ b/client/src/arcplanner/lib/src/ui/home_screen.dart
@@ -30,128 +30,86 @@ class HomeScreen extends StatelessWidget {
     bool firstTimeLoading = true;
     
 
-    return Scaffold(
-      backgroundColor: Colors.white,
+    return DefaultTabController(
+      length: 2,
+      child: Scaffold(
+        backgroundColor: Colors.white,
 
-      appBar: AppBar(
-        title: Text("Today is " 
-          + DateFormat.MEd().format(DateTime.now()),
+        appBar: AppBar(
+          bottom: TabBar(
+            tabs: <Widget>[
+              Tab(
+                text: 'Upcoming Tasks'
+              ),
+              Tab(
+                text: 'Past Due Tasks'
+              ),
+            ],
+          ),
+          title: Text("Today is " 
+            + DateFormat.MEd().format(DateTime.now()),
           ),
           centerTitle: true,
-          actions: <Widget>[
-            IconButton(
-              icon: Icon(Icons.add),
-              onPressed: () {
-                _newTask();
-              },
-            )
-          ],
-      ),
-
-      body: SafeArea(
-        child: Column(
-          children: <Widget>[
-            topBar(context),
-            Expanded(
-              child: StreamBuilder(
-                stream: bloc.homeStream,
-                builder: (context, snapshot) {
-                  return new FutureBuilder(
-                    future: snapshot.data,
-                    builder: (context, snapshot) {
-                      if (firstTimeLoading) {
-                        bloc.homeInsert({ 'object' : null, 'flag': 'getUpcomingItems'});
-                        firstTimeLoading = false;
-                      }
-                      
-                      if (snapshot.hasData) {
-                        dynamic snapshotData = snapshot.data;
-                        return ListView.builder(
-                          itemCount: snapshotData.length,
-                          itemBuilder: (context, index) {
-                            return tile(snapshotData[index], context);
-                          },
-                        );
-                      } else {
-                        return Text('There are no Arcs/Tasks');
-                      }
-                    },
-                  );
-                }
-              ),
-            ),
-          ],
-        ),
-      ),
-
-      drawer: drawerMenu(context),
-    );
-  }
-}
-
-Widget topBar(BuildContext context) {
-  var width = MediaQuery.of(context).size.width;
-  return Column(
-    children: <Widget>[
-    Container(
-        color: Colors.blue[400],
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          children: <Widget>[
+          actions: <Widget> [
             Container(
-              padding: EdgeInsets.all(8),
-              width: width * 0.60,
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: <Widget> [
-                  AutoSizeText(
-                    'Hello userName',
-                    style: TextStyle(
-                      fontSize: 30.0,
-                      color: Colors.white,
-                    ),
-                    maxLines: 1,
-                  ),
-                  AutoSizeText(
-                    'You have X upcoming tasks due in the next week',
-                    style: TextStyle(
-                      fontSize: 24.0,
-                      color: Colors.white,
-                    ),
-                    maxLines: 3,
-                  ),
-                ],
-              ),
-            ),
-            Container(
-              padding: EdgeInsets.only(
-                right: 10.0,
-              ),
               child: ButtonTheme(
-                height: 55.0,
-                buttonColor: Colors.white,
-                child: RaisedButton.icon(
-                  textColor: Colors.blue[400],
+                child: FlatButton.icon(
+                  textColor: Colors.white,
                   icon: Icon(
                     Icons.add,
-                    size: 45.0,
                   ),
                   label: Text(
                     'New\nTask',
                     style: TextStyle(
-                      fontSize: 20.0,
+                      fontSize: 14.0,
                     ),
                   ),
-                  // TODO: Replace _newTask with a Bloc method
-                  //onPressed: _newTask,
+                  onPressed: _newTask,
                 ),
               ),
             ),
           ],
         ),
+
+        body: SafeArea(
+          child: Column(
+            children: <Widget>[
+              Expanded(
+                child: StreamBuilder(
+                  stream: bloc.homeStream,
+                  builder: (context, snapshot) {
+                    return new FutureBuilder(
+                      future: snapshot.data,
+                      builder: (context, snapshot) {
+                        if (firstTimeLoading) {
+                          bloc.homeInsert({ 'object' : null, 'flag': 'getUpcomingItems'});
+                          firstTimeLoading = false;
+                        }
+                        
+                        if (snapshot.hasData) {
+                          dynamic snapshotData = snapshot.data;
+                          return ListView.builder(
+                            itemCount: snapshotData.length,
+                            itemBuilder: (context, index) {
+                              return tile(snapshotData[index], context);
+                            },
+                          );
+                        } else {
+                          return Text('There are no Arcs/Tasks');
+                        }
+                      },
+                    );
+                  }
+                ),
+              ),
+            ],
+          ),
+        ),
+
+        drawer: drawerMenu(context),
       ),
-    ],
-  );
+    );
+  }
 }
 
 Widget tile(dynamic obj, BuildContext context) {

--- a/client/src/arcplanner/lib/src/ui/task_tile.dart
+++ b/client/src/arcplanner/lib/src/ui/task_tile.dart
@@ -37,7 +37,7 @@ Widget taskTile(Task task, BuildContext context) {
         child: AutoSizeText(
           'Location: $location',
           style: TextStyle(
-            color: Colors.grey[600],
+            color: Colors.grey[800],
           ),
           maxFontSize: 14.0,
           minFontSize: 10.0,

--- a/client/src/arcplanner/lib/src/ui/task_tile.dart
+++ b/client/src/arcplanner/lib/src/ui/task_tile.dart
@@ -28,6 +28,28 @@ Widget taskTile(Task task, BuildContext context) {
     location = '';
   }
 
+  Widget getLocation() {
+    if (location != '') {
+      return Container(
+        padding: EdgeInsets.only(
+          top: 5.0,
+        ),
+        child: AutoSizeText(
+          'Location: $location',
+          style: TextStyle(
+            color: Colors.grey[600],
+          ),
+          maxFontSize: 14.0,
+          minFontSize: 10.0,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+        ),
+      );
+    } else {
+      return null;
+    }
+  }
+
   return Container(
     decoration: BoxDecoration(
       border: Border(
@@ -92,16 +114,7 @@ Widget taskTile(Task task, BuildContext context) {
               top: 0.0,
               bottom: 0.0,
             ),
-            child: AutoSizeText(
-              location,
-              style: TextStyle(
-                color: Colors.grey[800],
-              ),
-              maxFontSize: 18.0,
-              minFontSize: 12.0,
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-            ),
+            child: getLocation(),
           ),
           Container(
             padding: EdgeInsets.only(
@@ -128,3 +141,4 @@ Widget taskTile(Task task, BuildContext context) {
     ),
   );
 }
+


### PR DESCRIPTION
This PR fixes layout mismatches between Arc and Task tiles. It also hides the `location` empty output in a Task Tile if there is no location for a task. Additionally, the PR reworks the Home Screen UI and readies the screen to show both upcoming tasks and past due tasks.