### PR TITLE
Add BloC structure for Date related functions

### DIFF
--- a/client/src/arcplanner/lib/src/blocs/bloc.dart
+++ b/client/src/arcplanner/lib/src/blocs/bloc.dart
@@ -20,8 +20,10 @@ import '../util/databaseHelper.dart';
 import '../blocs/validators.dart';
 import 'package:rxdart/rxdart.dart';
 import '../helpers/date.dart';
+import 'package:intl/intl.dart';
 
 class Bloc extends Object with Validators {
+  var formatter = new DateFormat('yyyy-MM-dd');
   final DatabaseHelper db = DatabaseHelper();
   Map<String, dynamic> loadedObjects = Map<String, dynamic>();
 
@@ -314,15 +316,19 @@ class Bloc extends Object with Validators {
     // This section should be removed when we decide how to proceed
     // with defining `user` or removing the parameter from Arc constructor
     User tempUser = new User("Temp", "seashells", "this@that.com");
+    DateTime parsedDueDate = DateTime.parse(arcEndDate);
+    String formattedDueDate = formatter.format(parsedDueDate);
 
     if (arcParent == null) {
       Arc ar = new Arc(tempUser.uid, validArcTitle,
-          description: arcDescription, dueDate: arcEndDate);
+          description: arcDescription, 
+          dueDate: formattedDueDate);
       db.insertArc(ar);
     } else {
+
       Arc ar = new Arc(tempUser.uid, validArcTitle,
           description: arcDescription,
-          dueDate: arcEndDate,
+          dueDate: formattedDueDate,
           parentArc: arcParent.aid);
       db.insertArc(ar);
     }
@@ -339,9 +345,12 @@ class Bloc extends Object with Validators {
     final taskLocation = _taskLocationFieldController.value;
     final taskParent = _arcParentFieldController.value;
 
+    DateTime parsedDueDate = DateTime.parse(taskEndDate);
+    String formattedDueDate = formatter.format(parsedDueDate);
+
     Task tk = new Task(taskParent.aid, validTaskTitle,
         description: taskDescription,
-        dueDate: taskEndDate,
+        dueDate: formattedDueDate,
         location: taskLocation);
 
     db.insertTask(tk);

--- a/client/src/arcplanner/lib/src/helpers/date.dart
+++ b/client/src/arcplanner/lib/src/helpers/date.dart
@@ -13,7 +13,10 @@
  */
 
 import '../blocs/bloc.dart';
+import 'package:intl/intl.dart';
 
+Map<String, List<String>> loadedDates = Map<String, List<String>>();
+var formatter = new DateFormat('yyyy-MM-dd');
 
 /// Retrieves all Arcs and Tasks inclusively between the given two dates
 /// @param fromDate Represents the starting date of range of dates to be searched
@@ -21,17 +24,70 @@ import '../blocs/bloc.dart';
 /// @returns a future list of Arcs and Tasks from the data. This inherently will
 ///   result in maps of these objects
 Future<List<dynamic>> getItemsBetweenDates(String fromDate, String toDate) async {
-  List<Map> upcomingItemsMapList = await bloc.db.getItemsBetweenDates(fromDate, toDate);
-
   List<dynamic> upcomingItems = new List();
+  
+  if (checkIfDateRangeInMap(fromDate, toDate)) {
+    DateTime date = DateTime.parse(fromDate);
+    DateTime dayAfterEndDate = (DateTime.parse(toDate)).add(Duration(days:1));
+    while (date.isBefore(dayAfterEndDate)) {
+      List<String> uuids = loadedDates[formatter.format(date)];
+      for (String uuid in uuids) {
+        upcomingItems.add(bloc.getFromMap(uuid));
+      }
+    }
+  } else {
+    List<Map> upcomingItemsMapList = await bloc.db.getItemsBetweenDates(fromDate, toDate);
 
-  for (Map map in upcomingItemsMapList) {
-    bloc.insertObjectIntoMap(map);
-    if (map.containsKey('TID')) {
-      upcomingItems.add(bloc.toTask(map));
-    } else {
-      upcomingItems.add(bloc.toArc(map));
+    for (Map map in upcomingItemsMapList) {
+      bloc.insertObjectIntoMap(map);
+      addToLoadedDates(map);
+      if (map.containsKey('TID')) {
+        upcomingItems.add(bloc.toTask(map));
+      } else {
+        upcomingItems.add(bloc.toArc(map));
+      }
     }
   }
   return upcomingItems;
+}
+
+/// Checks to see if all dates are within the date range
+/// @param fromDate Represents the starting date of range of dates to be searched
+/// @param toDate Represents the ending date of range of dates to be searched
+/// @returns whether all dates exist in map. If at least 1 date is missing it 
+///   will return false
+bool checkIfDateRangeInMap(String fromDate, String toDate) {
+  DateTime date = DateTime.parse(fromDate);
+  DateTime dayAfterEndDate = (DateTime.parse(toDate)).add(Duration(days:1));
+  bool dateMissingInMap = false;
+  while (date.isBefore(dayAfterEndDate)) {
+    if (!loadedDates.containsKey(formatter.format(date))) {
+      dateMissingInMap = true;
+      break;
+    }
+    date.add(Duration(days:1));
+  }
+  
+  if (dateMissingInMap)
+    return false;
+  else
+    return true;
+}
+
+/// Adds map to the `loadedDates` object 
+/// @param map A map containing DueDate and the UUID of the object 
+void addToLoadedDates(Map map) {
+  if (loadedDates.containsKey(map['DueDate'])) {
+    if (map.containsKey('TID')) {
+      loadedDates.update(map['DueDate'], (dynamic listValue) => new List.from(listValue)..add(map['TID']));  //listValue.add(map['TID']));
+    } else {
+      loadedDates.update(map['DueDate'], (dynamic listValue) => new List.from(listValue)..add(map['AID']));
+    }
+  } else {
+    if (map.containsKey('TID')) {
+      loadedDates[map['DueDate']] = [map['TID']];
+    } else {
+      loadedDates[map['DueDate']] = [map['AID']];
+    }
+  }
 }


### PR DESCRIPTION
This PR makes it so that if objects were already pulled in from date related functions they do not need to be pulled in again from the DB but rather the map. The way it works is if any day in a range of requested dates is missing from a list of dates that were already loaded in then it will go to the db and pull all data. This makes the assumption if one date is missing then many could be missing and doesn't waste the time and fetches all dates in the range instead of wasting time trying to find each missing date. While this is not a perfect solution for maintaining the data if random dates are chosen, it should work well with our current infrastructure. With the current functions it should be easy to change in later dates if we find we are doing more random date ranges. 

In order to use this branch you will need to remove all objects from the DB as the `dueDate` format has been changed and will cause exceptions if any old objects remain.   

closes #107 