### PR TITLE
Delete arcs

### DIFF
--- a/client/src/arcplanner/lib/src/blocs/bloc.dart
+++ b/client/src/arcplanner/lib/src/blocs/bloc.dart
@@ -351,6 +351,7 @@ class Bloc extends Object with Validators {
       loadedObjects.remove(arc.aid);
     }
     await db.deleteArc(arc.aid);
+    
   }
 
 

--- a/client/src/arcplanner/lib/src/blocs/bloc.dart
+++ b/client/src/arcplanner/lib/src/blocs/bloc.dart
@@ -290,6 +290,14 @@ class Bloc extends Object with Validators {
     initializeAddArcStreams();
   }
 
+  editArc() {}
+
+  completeArc() {}
+
+  deleteArc(Arc arc) {
+    db.deleteArc(arc.aid);
+  }
+
   submitTask() {
     final validTaskTitle = _taskTitleFieldController.value;
     final taskEndDate = _taskEndDateFieldController.value;

--- a/client/src/arcplanner/lib/src/blocs/bloc.dart
+++ b/client/src/arcplanner/lib/src/blocs/bloc.dart
@@ -330,9 +330,9 @@ class Bloc extends Object with Validators {
     initializeAddArcStreams();
   }
 
-  editArc() {}
+  editArc(Arc arc) {}
 
-  completeArc() {}
+  completeArc(Arc arc) {}
 
   ///  Deletes an arc from the database BLOC
   ///  @param arc, the Arc to be deleted

--- a/client/src/arcplanner/lib/src/ui/add_arc_screen.dart
+++ b/client/src/arcplanner/lib/src/ui/add_arc_screen.dart
@@ -14,7 +14,7 @@
 
 import 'package:flutter/material.dart';
 import '../blocs/bloc.dart';
-import 'drawer_menu.dart';
+// import 'drawer_menu.dart';
 import 'parent_select_screen.dart';
 import 'package:intl/intl.dart';
 import 'package:datetime_picker_formfield/datetime_picker_formfield.dart';

--- a/client/src/arcplanner/lib/src/ui/arc_tile.dart
+++ b/client/src/arcplanner/lib/src/ui/arc_tile.dart
@@ -118,52 +118,24 @@ Widget arcTile(Arc arc, BuildContext context) {
         }
       },
       onLongPress: () {
-        // Show option to mark complete/delete
-            // if delete
-                // if has children
-                    // "no delete" message
-                // else
-                    // delete
-
-            // if complete
-              // if has incomplete children
-                  // "not complete" message
-              // if else, and all children complete
-                  // complete
-            // update for arcView
+        // if complete
+        // if has incomplete children
+        // "not complete" message
+        // if else, and all children complete
+        // complete
+        // update for arcView
 
         return showDialog<void>(
           context: context,
           builder: (BuildContext context) {
             return AlertDialog(
-              // title: Text("Make changes to this Arc?"),
               content: Column(
                 mainAxisAlignment: MainAxisAlignment.center,
                 mainAxisSize: MainAxisSize.min,
                 children: <Widget>[
-                  FlatButton(  // leaving this commented until edit is implemented
-                    
-                    textColor: Colors.blue,
-              
-                    child: Text('Edit', style: TextStyle(fontWeight: FontWeight.bold)),
-                    onPressed: () {
-                      Navigator.of(context).pop();
-                    },
-                  ),
-                  FlatButton(
-                    textColor: Colors.blue,
-                    child: Text('Mark Complete', style: TextStyle(fontWeight: FontWeight.bold)),
-                    onPressed: () {
-                      Navigator.of(context).pop();
-                    },
-                  ),
-                  FlatButton(
-                    textColor: Colors.blue,
-                    child: Text('Delete', style: TextStyle(fontWeight: FontWeight.bold)),
-                    onPressed: () {
-                      Navigator.of(context).pop();
-                    },
-                  ),
+                  editArc(arc),
+                  completeArc(arc),
+                  deleteArc(arc),
                 ],
               ),
             );
@@ -171,5 +143,77 @@ Widget arcTile(Arc arc, BuildContext context) {
         );
       },
     ),
+  );
+}
+
+Widget editArc(Arc arc) {
+  return StreamBuilder(
+    stream: bloc.arcTitleFieldStream,
+    builder: (context, snapshot) {
+      return FlatButton(
+        textColor: Colors.blue,
+        child: Text('Edit', style: TextStyle(fontWeight: FontWeight.bold)),
+        onPressed: () {
+          bloc.editArc();
+          // edit screen?
+          Navigator.of(context).pop();
+        },
+      );
+    },
+  );
+}
+
+Widget completeArc(Arc arc) {
+  return StreamBuilder(
+    stream: bloc.arcTitleFieldStream,
+    builder: (context, snapshot) {
+      return FlatButton(
+        textColor: Colors.blue,
+        child:
+            Text('Complete Arc', style: TextStyle(fontWeight: FontWeight.bold)),
+        onPressed: () {
+          bloc.completeArc();
+          //mark complete
+          Navigator.of(context).pop();
+        },
+      );
+    },
+  );
+}
+
+Widget deleteArc(Arc arc) {
+  return StreamBuilder(
+    stream: bloc.arcTitleFieldStream,
+    builder: (context, snapshot) {
+      return FlatButton(
+        textColor: Colors.blue,
+        child: Text('Delete', style: TextStyle(fontWeight: FontWeight.bold)),
+        onPressed: () {
+          if (arc.childrenUUIDs == null) {
+            print("delete the arc");
+            bloc.deleteArc(arc);
+          } else {
+            print("Arc has children");
+            return showDialog(
+                context: context,
+                builder: (BuildContext context) {
+                  return AlertDialog(
+                      content: Column(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          mainAxisSize: MainAxisSize.min,
+                          children: <Widget>[
+                        Text("Cannot delete Arc with existing tasks or arcs."),
+                        FlatButton(
+                            child: Text("OK"),
+                            onPressed: () {
+                              Navigator.of(context).pop();
+                            })
+                      ]));
+                });
+          }
+          Navigator.of(context).pop();
+        },
+      );
+    },
   );
 }

--- a/client/src/arcplanner/lib/src/ui/arc_tile.dart
+++ b/client/src/arcplanner/lib/src/ui/arc_tile.dart
@@ -154,7 +154,7 @@ Widget editArc(Arc arc) {
         textColor: Colors.blue,
         child: Text('Edit', style: TextStyle(fontWeight: FontWeight.bold)),
         onPressed: () {
-          bloc.editArc();
+          bloc.editArc(arc);
           // edit screen?
           Navigator.of(context).pop();
         },
@@ -172,7 +172,7 @@ Widget completeArc(Arc arc) {
         child:
             Text('Complete Arc', style: TextStyle(fontWeight: FontWeight.bold)),
         onPressed: () {
-          bloc.completeArc();
+          bloc.completeArc(arc);
           //mark complete
           Navigator.of(context).pop();
         },

--- a/client/src/arcplanner/lib/src/ui/arc_tile.dart
+++ b/client/src/arcplanner/lib/src/ui/arc_tile.dart
@@ -190,11 +190,9 @@ Widget deleteArc(Arc arc) {
         child: Text('Delete', style: TextStyle(fontWeight: FontWeight.bold)),
         onPressed: () {
           if (arc.childrenUUIDs == null) {
-            print("delete the arc");
             bloc.deleteArc(arc);
             // TODO update current screen (arcview or home)
           } else {
-            print("Arc has children");
             return showDialog(
                 context: context,
                 builder: (BuildContext context) {

--- a/client/src/arcplanner/lib/src/ui/arc_tile.dart
+++ b/client/src/arcplanner/lib/src/ui/arc_tile.dart
@@ -19,9 +19,7 @@ import 'package:auto_size_text/auto_size_text.dart';
 import 'arc_view_screen.dart';
 import 'package:intl/intl.dart';
 
-
 Widget arcTile(Arc arc, BuildContext context) {
-  
   var description = arc.description;
 
   ArcViewScreen.currentParent = arc.parentArc;
@@ -55,7 +53,8 @@ Widget arcTile(Arc arc, BuildContext context) {
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: <Widget>[
-                      Text('Arc',
+                      Text(
+                        'Arc',
                         style: TextStyle(
                           fontSize: 8.0,
                         ),
@@ -76,8 +75,9 @@ Widget arcTile(Arc arc, BuildContext context) {
                 ),
                 Container(
                   child: AutoSizeText(
-                    (arc.dueDate == 'null' || arc.dueDate == null) ? '' 
-                     : DateFormat.yMEd().format(DateTime.parse(arc.dueDate)),
+                    (arc.dueDate == 'null' || arc.dueDate == null)
+                        ? ''
+                        : DateFormat.yMEd().format(DateTime.parse(arc.dueDate)),
                     style: TextStyle(
                       color: Colors.black,
                     ),
@@ -95,7 +95,8 @@ Widget arcTile(Arc arc, BuildContext context) {
               top: 5.0,
               bottom: 10.0,
             ),
-            child: AutoSizeText(description,
+            child: AutoSizeText(
+              description,
               style: TextStyle(
                 color: Colors.grey[600],
               ),
@@ -111,12 +112,64 @@ Widget arcTile(Arc arc, BuildContext context) {
         //If going to a screen that shows no children then set flag to true
         if (arc.childrenUUIDs?.isEmpty ?? true) {
           ArcViewScreen.atNoArcTaskScreen = true;
-          bloc.arcViewInsert({ 'object' : null, 'flag': 'clear'});
+          bloc.arcViewInsert({'object': null, 'flag': 'clear'});
         } else {
-          bloc.arcViewInsert({ 'object' : arc.aid, 'flag': 'getChildren'});
+          bloc.arcViewInsert({'object': arc.aid, 'flag': 'getChildren'});
         }
-      } 
-      //onLongPress: ,
+      },
+      onLongPress: () {
+        // Show option to mark complete/delete
+            // if delete
+                // if has children
+                    // "no delete" message
+                // else
+                    // delete
+
+            // if complete
+              // if has incomplete children
+                  // "not complete" message
+              // if else, and all children complete
+                  // complete
+            // update for arcView
+
+        return showDialog<void>(
+          context: context,
+          builder: (BuildContext context) {
+            return AlertDialog(
+              // title: Text("Make changes to this Arc?"),
+              content: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                mainAxisSize: MainAxisSize.min,
+                children: <Widget>[
+                  FlatButton(  // leaving this commented until edit is implemented
+                    
+                    textColor: Colors.blue,
+              
+                    child: Text('Edit', style: TextStyle(fontWeight: FontWeight.bold)),
+                    onPressed: () {
+                      Navigator.of(context).pop();
+                    },
+                  ),
+                  FlatButton(
+                    textColor: Colors.blue,
+                    child: Text('Mark Complete', style: TextStyle(fontWeight: FontWeight.bold)),
+                    onPressed: () {
+                      Navigator.of(context).pop();
+                    },
+                  ),
+                  FlatButton(
+                    textColor: Colors.blue,
+                    child: Text('Delete', style: TextStyle(fontWeight: FontWeight.bold)),
+                    onPressed: () {
+                      Navigator.of(context).pop();
+                    },
+                  ),
+                ],
+              ),
+            );
+          },
+        );
+      },
     ),
   );
 }

--- a/client/src/arcplanner/lib/src/ui/arc_tile.dart
+++ b/client/src/arcplanner/lib/src/ui/arc_tile.dart
@@ -4,7 +4,7 @@
  *
  *  Authors: 
  *    Primary: Matthew Chastain
- *    Contributors: Kevin Kelly
+ *    Contributors: Kevin Kelly, Jonathan Middleton
  * 
  *  Provided as is. No warranties expressed or implied. Use at your own risk.
  *
@@ -192,6 +192,7 @@ Widget deleteArc(Arc arc) {
           if (arc.childrenUUIDs == null) {
             print("delete the arc");
             bloc.deleteArc(arc);
+            // TODO update current screen (arcview or home)
           } else {
             print("Arc has children");
             return showDialog(

--- a/client/src/arcplanner/lib/src/ui/arc_tile.dart
+++ b/client/src/arcplanner/lib/src/ui/arc_tile.dart
@@ -118,13 +118,6 @@ Widget arcTile(Arc arc, BuildContext context) {
         }
       },
       onLongPress: () {
-        // if complete
-        // if has incomplete children
-        // "not complete" message
-        // if else, and all children complete
-        // complete
-        // update for arcView
-
         return showDialog<void>(
           context: context,
           builder: (BuildContext context) {

--- a/client/src/arcplanner/lib/src/util/databaseHelper.dart
+++ b/client/src/arcplanner/lib/src/util/databaseHelper.dart
@@ -175,7 +175,7 @@ class DatabaseHelper {
   // pulls a single Arc from db given a UUID
   Future<List<Map>> getArc(String uuid) async {
     var dbClient = await db;
-    return await dbClient.rawQuery('SELECT 1 FROM Arc WHERE AID = $uuid');
+    return await dbClient.rawQuery("SELECT 1 FROM Arc WHERE AID = '$uuid'");
   } 
 
   // pulls a single Task from db given a UUID

--- a/client/src/arcplanner/pubspec.yaml
+++ b/client/src/arcplanner/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   uuid: 2.0.0
   auto_size_text: ^1.1.1
   datetime_picker_formfield: ^0.1.8
-  table_calendar: 1.1.4
+  table_calendar: ^1.1.4
   intl: ^0.15.8
 
 

--- a/client/src/arcplanner/pubspec.yaml
+++ b/client/src/arcplanner/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   uuid: 2.0.0
   auto_size_text: ^1.1.1
   datetime_picker_formfield: ^0.1.8
-  table_calendar: ^1.1.4
+  table_calendar: 1.1.4
   intl: ^0.15.8
 
 


### PR DESCRIPTION
Closes #16. Deletes an arc if it has no children objects. Displays a message to the user if the arc *does* have children objects.

A couple things to note:
If sending a query to SQLite that has a UUID, use quotes around the `$variable` part of the phrase. ex:
`dbClient.rawQuery('SELECT * FROM Arc WHERE ParentArc = "$uuid"');`

SQLite thinks that the UUID is a number when it is meant to be treated like a string. When it sees the dashes, it throws an exception. Adding the extra set of quotes fixes this.

I had some issues deleting an arc if it was the only arc left, but was not able to recreate the issue. I did reinstall the app on both an emulator and my Pixel handset, so the reinstall might have been the fix. Nevertheless, pay special attention to this when testing out these changes.