### PR TITLE
fix issue with back button

### DIFF
--- a/client/src/arcplanner/lib/src/ui/task_tile.dart
+++ b/client/src/arcplanner/lib/src/ui/task_tile.dart
@@ -16,8 +16,10 @@ import 'package:flutter/material.dart';
 import '../model/task.dart';
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:intl/intl.dart';
+import 'arc_view_screen.dart';
 
 Widget taskTile(Task task, BuildContext context) {
+  ArcViewScreen.currentParent = task.aid;
   var description = task.description;
   if (description == null) {
     description = 'No Description';


### PR DESCRIPTION
This PR fixes the issue with back button where if all tiles in the arc view screen are tasks the back button does not work correctly. This was causes by the addition of tasks to arc view after back button creation on the screen. The same methodology that was on `arc_tile.dart` for back button was moved over to `task_tile.dart` which solved the issue.

Closes #115 