### PR TITLE
Merge get child functions

### DIFF
--- a/client/src/arcplanner/lib/src/blocs/bloc.dart
+++ b/client/src/arcplanner/lib/src/blocs/bloc.dart
@@ -141,7 +141,7 @@ class Bloc extends Object with Validators {
     } else if (data['flag'] == "getChildren") {
       return await getChildren(data['object']);
     } else if (data['flag'] == "getChildArcs") {
-      return await getChildArcs(data['object']);
+      return await getChildren(data['object'], tasks: false);
     } else if (data['flag'] == "backButton") {
       Arc parent = getFromMap(data['object']);
       return await getChildren(parent.parentArc);
@@ -235,7 +235,7 @@ class Bloc extends Object with Validators {
   ///   to the UI via stream
   /// @param parentUUID the UUID of the parent whos children will be returned
   /// @returns All Tasks and Arcs that have `parentUUID` set as their `parentArc`
-  Future<List<dynamic>> getChildren(String parentUUID) async {
+  Future<List<dynamic>> getChildren(String parentUUID, {arcs = true, tasks = true}) async {
     List<dynamic> children = new List();
 
     // If there is no supplied UUID supply parentArc = null, the masterArcs
@@ -258,7 +258,7 @@ class Bloc extends Object with Validators {
         } else {
           // If one child UUID is missing use query to get all children and
           //  add to map. This is to avoid many queries if large list of children
-          children = insertListIntoMap(await db.getChildren(parentUUID));
+          children = insertListIntoMap(await db.getChildren(parentUUID, arcs: arcs, tasks: tasks));
           break;
         }
       }

--- a/client/src/arcplanner/lib/src/blocs/bloc.dart
+++ b/client/src/arcplanner/lib/src/blocs/bloc.dart
@@ -234,6 +234,8 @@ class Bloc extends Object with Validators {
   ///   back via stream. Otherwise load them from database and into map. Then
   ///   to the UI via stream
   /// @param parentUUID the UUID of the parent whos children will be returned
+  /// @param arcs determines whether arcs should be returned. Default is true
+  /// @param tasks determines whether tasks should be returned. Default is true
   /// @returns All Tasks and Arcs that have `parentUUID` set as their `parentArc`
   Future<List<dynamic>> getChildren(String parentUUID, {arcs = true, tasks = true}) async {
     List<dynamic> children = new List();

--- a/client/src/arcplanner/lib/src/blocs/bloc.dart
+++ b/client/src/arcplanner/lib/src/blocs/bloc.dart
@@ -266,42 +266,6 @@ class Bloc extends Object with Validators {
     return children;
   }
 
-  /// Checks to see if children are in map. If they exist in map then send them
-  ///   back via stream. Otherwise load them from database and into map. Then
-  ///   to the UI via stream
-  /// @param parentUUID the UUID of the parent whos children will be returned
-  /// @returns All Arcs that have `parentUUID` set as their `parentArc`
-  Future<List<dynamic>> getChildArcs(String parentUUID) async {
-    List<dynamic> children = new List();
-
-    // If there is no supplied UUID supply parentArc = null, the masterArcs
-    if (parentUUID == null) {
-      children = insertListIntoMap(await db.getMasterArcs());
-      return children;
-    }
-
-    Arc parent = getFromMap(parentUUID);
-
-    // If childrenUUIDs is empty then it has no children
-    if (parent.childrenUUIDs?.isEmpty ?? true) {
-      // Key does not exist in map yet or doesn't have children
-      return null;
-    } else {
-      // If Children exist in map already
-      for (String uuid in parent.childrenUUIDs) {
-        if (checkMap(uuid)) {
-          children.add(getFromMap(uuid));
-        } else {
-          // If one child UUID is missing use query to get all children and
-          //  add to map. This is to avoid many queries if large list of children
-          children = insertListIntoMap(await db.getChildArcs(parentUUID));
-          break;
-        }
-      }
-    }
-    return children;
-  }
-
   /// Using the various streams from `add_arc_screen.dart` an arc object is
   ///   created and then added to the database
   void submitArc() {

--- a/client/src/arcplanner/lib/src/util/databaseHelper.dart
+++ b/client/src/arcplanner/lib/src/util/databaseHelper.dart
@@ -232,15 +232,6 @@ class DatabaseHelper {
     return new List.from(arcList)..addAll(taskList);
   }
 
-  /// Returns a list of mapped children of the given Arc, only arcs
-  /// @param uuid the UUID of the parent Arc
-  /// @returns a list of all children Arcs
-  Future<List<Map>> getChildArcs(String uuid) async {
-    var dbClient = await db;
-    List<Map> arcList = await dbClient.rawQuery('SELECT * FROM Arc WHERE ParentArc = "$uuid"');
-    return arcList;
-  }
-
   /// Retrieves all Arcs from the database
   /// @returns All Arcs in the database
   Future<List<Map>> getArcList() async {

--- a/client/src/arcplanner/lib/src/util/databaseHelper.dart
+++ b/client/src/arcplanner/lib/src/util/databaseHelper.dart
@@ -202,14 +202,22 @@ class DatabaseHelper {
   /// Returns a list of mapped children of the given Arc
   /// @param uuid the UUID of the parent Arc
   /// @returns a list of all children Tasks and Arcs
-  Future<List<Map>> getChildren(String uuid) async {
+  Future<List<Map>> getChildren(String uuid, {arcs = true, tasks = true}) async {
     var dbClient = await db;
-    List<Map> arcList = await dbClient.rawQuery('SELECT * FROM Arc WHERE ParentArc = "$uuid"');
-    if (uuid != null) {
+    if (arcs && tasks) {
+      List<Map> arcList = await dbClient.rawQuery('SELECT * FROM Arc WHERE ParentArc = "$uuid"');
+      if (uuid != null) {
+        List<Map> taskList = await dbClient.rawQuery('SELECT * FROM Task WHERE AID = "$uuid"');
+        return new List.from(arcList)..addAll(taskList);
+      } else
+        return arcList;
+    } else if (arcs && !tasks) {
+        List<Map> arcList = await dbClient.rawQuery('SELECT * FROM Arc WHERE ParentArc = "$uuid"');
+        return arcList;
+    } else {
       List<Map> taskList = await dbClient.rawQuery('SELECT * FROM Task WHERE AID = "$uuid"');
-      return new List.from(arcList)..addAll(taskList);
-    } else
-      return arcList;
+      return taskList;
+    }
   }
 
   /// Retrieves all Arcs and Tasks inclusively between the given two dates. 

--- a/client/src/arcplanner/lib/src/util/databaseHelper.dart
+++ b/client/src/arcplanner/lib/src/util/databaseHelper.dart
@@ -201,6 +201,8 @@ class DatabaseHelper {
 
   /// Returns a list of mapped children of the given Arc
   /// @param uuid the UUID of the parent Arc
+  /// @param arcs determines whether arcs should be returned. Default is true
+  /// @param tasks determines whether tasks should be returned. Default is true
   /// @returns a list of all children Tasks and Arcs
   Future<List<Map>> getChildren(String uuid, {arcs = true, tasks = true}) async {
     var dbClient = await db;


### PR DESCRIPTION
As #117 states there are two almost identical getChildren functions. This PR merges them with by adding two boolean parameters to `getChildren` function, `arcs` and `tasks`. They are set to true by default and determine whether the represented object type should be returned.

Closes #117 