### PR TITLE
Update objects and database to support time due

### DIFF
--- a/client/src/arcplanner/lib/src/blocs/bloc.dart
+++ b/client/src/arcplanner/lib/src/blocs/bloc.dart
@@ -162,6 +162,7 @@ class Bloc extends Object with Validators {
     return Arc.read(map['UID'], map['AID'], map['Title'],
         description: map['Description'],
         dueDate: map['DueDate'],
+        timeDue: map['TimeDue'],
         parentArc: map['ParentArc'],
         completed: map['Completed'],
         childrenUUIDs: map['ChildrenUUIDs']);
@@ -176,6 +177,7 @@ class Bloc extends Object with Validators {
     return Task.read(map['TID'], map['AID'], map['Title'],
         description: map['Description'],
         dueDate: map['DueDate'],
+        timeDue: map['TimeDue'],
         location: map['Location'],
         completed: map['Completed']);
   }

--- a/client/src/arcplanner/lib/src/model/arc.dart
+++ b/client/src/arcplanner/lib/src/model/arc.dart
@@ -20,6 +20,7 @@ class Arc {
   String _title;
   String _description;
   String _dueDate;
+  String _timeDue;
   String _parentArc;
   bool _completed;
   List<String> childrenUUIDs = new List();
@@ -33,10 +34,11 @@ class Arc {
   ///   of the given arc. The default is null
   /// @param parentArc an optional parameter representing the UUID of the parent
   ///   arc. The default is null
-  Arc(this._uid, this._title, {description, dueDate, parentArc}) {
+  Arc(this._uid, this._title, {description, timeDue, dueDate, parentArc,}) {
     this._aid = new Uuid().v4();
     this._description = description;
     this._dueDate = dueDate;
+    this._timeDue = timeDue;
     this._parentArc = parentArc;
     this._completed = false;
   }
@@ -55,9 +57,10 @@ class Arc {
   /// @param childrenUUIDs A list of UUIDs repesenting the UUIDs of the children
   ///   Arcs and Tasks
   Arc.read(this._uid, this._aid, this._title, 
-      {description, dueDate, parentArc, completed, childrenUUIDs}) {
+      {description, dueDate, timeDue, parentArc, completed, childrenUUIDs}) {
     this._description = description;
     this._dueDate = dueDate;
+    this._timeDue = timeDue;
     this._parentArc = parentArc;
     this.childrenUUIDs = childrenUUIDs?.split(",");
     if (completed == '1') {
@@ -74,6 +77,7 @@ class Arc {
     _title = obj["title"];
     _description = obj["description"];
     _dueDate = obj["dueDate"];
+    _timeDue = obj["TimeDue"];
     _parentArc = obj["parentarc"];
     _completed = obj["completed"];
   }
@@ -95,6 +99,7 @@ class Arc {
     map["title"] = _title;
     map["description"] = _description;
     map["dueDate"] = _dueDate;
+    map["timeDue"] = _timeDue;
     map["parentarc"] = _parentArc;
     map["completed"] =_completed;
 
@@ -111,6 +116,7 @@ class Arc {
     _title = map["title"];
     _description = map["description"];
     _dueDate = map["dueDate"];
+    _timeDue = map["timeDue"];
     _parentArc = map["parentarc"];
     _completed = map["completed"];
   }

--- a/client/src/arcplanner/lib/src/model/task.dart
+++ b/client/src/arcplanner/lib/src/model/task.dart
@@ -21,6 +21,7 @@ class Task {
   String _title;
   String _description;
   String _dueDate; // SQLite will store the dueDate as TEXT type
+  String _timeDue; // SQLite will store the dueDate as TEXT type
   String _location;
   bool _completed;
 
@@ -32,10 +33,11 @@ class Task {
   ///   of the Task. The default is null
   /// @param location an optional parameter representing the location where
   ///   task is to be completed. The default is null
-  Task(this._aid, this._title, {description, dueDate, location}) {
+  Task(this._aid, this._title, {description, dueDate, timeDue, location}) {
     this._tid = new Uuid().v4();
     this._description = description;
     this._dueDate = dueDate;
+    this._timeDue = timeDue;
     this._location = location;
     this._completed = false;
   }
@@ -49,9 +51,10 @@ class Task {
   /// @param location an optional parameter representing the location where
   ///   task is to be completed. The default is null
   Task.read(this._tid, this._aid, this._title, 
-      {description, dueDate, location, completed}) {
+      {description, dueDate, location, timeDue, completed}) {
     this._description = description;
     this._dueDate = dueDate;
+    this._timeDue = timeDue;
     this._location = location;
     if (completed == 'true') {
       this._completed = true;
@@ -68,6 +71,7 @@ class Task {
     _title = obj["title"];
     _description = obj["description"];
     _dueDate = obj["duedate"];
+    _timeDue = obj["timeDue"];
     _location = obj["location"];
     _completed = obj["completed"];
   }
@@ -89,6 +93,7 @@ class Task {
     map["title"] = _title;
     map["description"] = _description;
     map["duedate"] = _dueDate;
+    map["timeDue"] = _timeDue;
     map["location"] = _location;
     map["completed"] = _completed;
 
@@ -105,6 +110,7 @@ class Task {
     _title = map["title"];
     _description = map["description"];
     _dueDate = map["duedate"];
+    _timeDue = map["timeDue"];
     _location = map["location"];
     _completed = map["completed"];
   }

--- a/client/src/arcplanner/lib/src/util/databaseHelper.dart
+++ b/client/src/arcplanner/lib/src/util/databaseHelper.dart
@@ -126,7 +126,7 @@ class DatabaseHelper {
           )""");
     await db.execute("""
         CREATE VIEW $_arcView AS
-        SELECT UID, AID, Title, Description, DueDate, TimeDue ParentArc, Completed, 
+        SELECT UID, AID, Title, Description, DueDate, TimeDue, ParentArc, Completed, 
           ( SELECT group_concat(UUID)
             FROM (
               SELECT Arc2.AID AS UUID

--- a/client/src/arcplanner/lib/src/util/databaseHelper.dart
+++ b/client/src/arcplanner/lib/src/util/databaseHelper.dart
@@ -47,6 +47,7 @@ class DatabaseHelper {
   static final String _arcTitle = "Title";
   static final String _arcDesc = "Description";
   static final String _arcDueDate = "DueDate";
+  static final String _arcTimeDue = "TimeDue";
   static final String _arcPArc = "ParentArc";
   static final String _arcCompleted = "Completed";
 
@@ -56,6 +57,7 @@ class DatabaseHelper {
   static final String _taskTitle = "Title";
   static final String _taskDesc = "Description";
   static final String _taskDueDate = "DueDate";
+   static final String _taskTimeDue = "TimeDue";
   static final String _taskLoc = "Location";
   static final String _taskCompleted = "Completed";
 
@@ -107,6 +109,7 @@ class DatabaseHelper {
           $_arcTitle TEXT NOT NULL CHECK(LENGTH($_arcTitle) <= $_nameSize), 
           $_arcDesc TEXT, 
           $_arcDueDate TEXT,
+          $_arcTimeDue TEXT,
           $_arcPArc TEXT CHECK(LENGTH($_arcPArc) = $_uuidSize),
           $_arcCompleted INTEGER CHECK($_arcCompleted == 0 OR $_arcCompleted == 1)
           )""");
@@ -116,13 +119,14 @@ class DatabaseHelper {
           $_taskTID TEXT PRIMARY KEY CHECK(LENGTH($_taskTID) = $_uuidSize), 
           $_taskTitle TEXT CHECK(LENGTH($_taskTitle) <= $_nameSize), 
           $_taskDesc TEXT, 
-          $_taskDueDate TEXT, 
+          $_taskDueDate TEXT,
+          $_taskTimeDue TEXT,
           $_taskLoc TEXT CHECK(LENGTH($_taskLoc) <= $_locSize),
           $_taskCompleted INTEGER CHECK($_taskCompleted == 0 OR $_taskCompleted == 1)
           )""");
     await db.execute("""
         CREATE VIEW $_arcView AS
-        SELECT UID, AID, Title, Description, DueDate, ParentArc, Completed, 
+        SELECT UID, AID, Title, Description, DueDate, TimeDue ParentArc, Completed, 
           ( SELECT group_concat(UUID)
             FROM (
               SELECT Arc2.AID AS UUID


### PR DESCRIPTION
This PR adds time due to tasks and arcs objects. This PR does not add this to the UI but sets the objects up so it can be easily stored and read from the objects with the current functions within the app.

This PR does not update the PostgreSQL tables with this attribute as it would interrupt the currently outstanding PR #84 

Closes #121 