### PR TITLE
Feat complete tasks

### DIFF
--- a/client/src/arcplanner/lib/src/blocs/bloc.dart
+++ b/client/src/arcplanner/lib/src/blocs/bloc.dart
@@ -389,8 +389,9 @@ class Bloc extends Object with Validators {
 
   editTask(Task task){}
 
-  completeTask(Task task){
+  completeTask(Task task) async {
     task.completeTask();
+    await db.updateTask(task);
   }
 
   ///  Deletes a task from the database BLOC

--- a/client/src/arcplanner/lib/src/blocs/bloc.dart
+++ b/client/src/arcplanner/lib/src/blocs/bloc.dart
@@ -389,7 +389,9 @@ class Bloc extends Object with Validators {
 
   editTask(Task task){}
 
-  completeTask(Task task){}
+  completeTask(Task task){
+    task.completeTask();
+  }
 
   ///  Deletes a task from the database BLOC
   ///  Removes reference to itself if it has a parent; deletes task from

--- a/client/src/arcplanner/lib/src/model/task.dart
+++ b/client/src/arcplanner/lib/src/model/task.dart
@@ -1,3 +1,4 @@
+import 'package:arcplanner/src/helpers/date.dart';
 /** 
  *  Team CGKM - Matthew Chastain, Justin Grabowski, Kevin Kelly, Jonathan Middleton
  *  CS298 Spring 2019 
@@ -56,7 +57,7 @@ class Task {
     this._dueDate = dueDate;
     this._timeDue = timeDue;
     this._location = location;
-    if (completed == 'true') {
+    if (completed == 1 || completed == 'true') {
       this._completed = true;
     } else {
       this._completed = false;
@@ -105,12 +106,7 @@ class Task {
   /*
   * Description: Updates the SQLite related task completed field to true. It then also changes its on instance variable to true.
   */
-  void completeTask() async{
-    var db = new DatabaseHelper();
-
+  void completeTask() {
     _completed = true;
-    
-    // Update database with updated task
-    await db.updateTask(this);
   } 
 }

--- a/client/src/arcplanner/lib/src/model/task.dart
+++ b/client/src/arcplanner/lib/src/model/task.dart
@@ -105,12 +105,12 @@ class Task {
   /*
   * Description: Updates the SQLite related task completed field to true. It then also changes its on instance variable to true.
   */
-  void completeTask() {
+  void completeTask() async{
     var db = new DatabaseHelper();
 
     _completed = true;
     
     // Update database with updated task
-    db.updateTask(this);
+    await db.updateTask(this);
   } 
 }

--- a/client/src/arcplanner/lib/src/ui/task_tile.dart
+++ b/client/src/arcplanner/lib/src/ui/task_tile.dart
@@ -98,17 +98,22 @@ Widget taskTile(Task task, BuildContext context) {
                 ),
               ),
               Container(
-                child: AutoSizeText(
-                  (task.dueDate == 'null' || task.dueDate == null)
-                      ? ''
-                      : DateFormat.yMEd().format(DateTime.parse(task.dueDate)),
-                  style: TextStyle(
-                    color: Colors.black,
-                  ),
-                  maxFontSize: 14.0,
-                  minFontSize: 14.0,
-                  maxLines: 4,
-                  overflow: TextOverflow.ellipsis,
+                child: Column(
+                  children: <Widget>[   
+                    AutoSizeText(
+                      (task.dueDate == 'null' || task.dueDate == null)
+                          ? ''
+                          : DateFormat.yMEd().format(DateTime.parse(task.dueDate)),
+                      style: TextStyle(
+                        color: Colors.black,
+                      ),
+                      maxFontSize: 14.0,
+                      minFontSize: 14.0,
+                      maxLines: 4,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    Text(task.completed == true ? 'Complete': ''),
+                  ],
                 ),
               ),
             ],

--- a/client/src/arcplanner/lib/src/ui/task_tile.dart
+++ b/client/src/arcplanner/lib/src/ui/task_tile.dart
@@ -193,7 +193,7 @@ Widget completeTask(Task task) {
             style: TextStyle(fontWeight: FontWeight.bold)),
         onPressed: () {
           bloc.completeTask(task);
-          //mark complete
+          bloc.arcViewInsert({ 'object' : task.aid, 'flag': 'getChildren'});
           Navigator.of(context).pop();
         },
       );

--- a/client/src/arcplanner/lib/src/ui/task_tile.dart
+++ b/client/src/arcplanner/lib/src/ui/task_tile.dart
@@ -194,6 +194,7 @@ Widget completeTask(Task task) {
         onPressed: () {
           bloc.completeTask(task);
           bloc.arcViewInsert({ 'object' : task.aid, 'flag': 'getChildren'});
+          bloc.homeInsert({ 'object' : null, 'flag': 'getUpcomingItems'});
           Navigator.of(context).pop();
         },
       );


### PR DESCRIPTION
This PR adds the ability for a `Task`to be marked as complete and closes #119 

Note: I had an issue in displaying the value of the `completed` field for tasks, which required the addition of a test for (completed == 1) in the `Teask.read` constructor. 

- I believe this is due to the value of `completed` being stored as a `bool` in the `Task` object and even though the value of `completed` is a `String` in the `Task` table, its value is stored as a 0 or 1

- I am not 100% sure this is the reason but based upon my testing I think it is, additionally I updated the  databaseHelper's `updateTask` function as shown below to run a test 

<img width="587" alt="Screen Shot 2019-05-07 at 1 06 04 PM" src="https://user-images.githubusercontent.com/36801761/57318681-e0df2000-70c8-11e9-89ac-ac2f4d09ee2c.png">

The result printed to the console was:

<img width="587" alt="Screen Shot 2019-05-07 at 1 08 16 PM" src="https://user-images.githubusercontent.com/36801761/57318822-2f8cba00-70c9-11e9-9bc5-97dcc55f3715.png">

As shown, the value of completed is: 1
