### PR TITLE
Make task's parent optional

### DIFF
--- a/client/src/arcplanner/lib/src/blocs/bloc.dart
+++ b/client/src/arcplanner/lib/src/blocs/bloc.dart
@@ -107,8 +107,8 @@ class Bloc extends Object with Validators {
   Stream<String> get taskLocationFieldStream =>
       _taskLocationFieldController.stream;
 
-  Stream<bool> get submitValidTask => Observable.combineLatest2(
-      taskTitleFieldStream, arcParentFieldStream, (t, d) => true);
+
+  Stream<bool> get submitValidTask => taskTitleFieldStream.map((_) => true);
 
   // Change data for Add Task Screen
   Function(String) get changeTaskTitle => _taskTitleFieldController.sink.add;
@@ -185,7 +185,8 @@ class Bloc extends Object with Validators {
   /// @param map A map of a Task object
   /// @returns The Task object that was constructed 
   Task toTask(Map map) {
-    return Task.read(map['TID'], map['AID'], map['Title'],
+    return Task.read(map['TID'], map['Title'],
+        aid: map['AID'],
         description: map['Description'],
         dueDate: map['DueDate'],
         timeDue: map['TimeDue'],
@@ -359,12 +360,20 @@ class Bloc extends Object with Validators {
       formattedDueDate = formatter.format(parsedDueDate);
     }
 
-    Task tk = new Task(taskParent.aid, validTaskTitle,
+    if (taskParent == null) {
+      Task tk = new Task(validTaskTitle,
         description: taskDescription,
         dueDate: formattedDueDate,
         location: taskLocation);
-
-    db.insertTask(tk);
+      db.insertTask(tk);
+    } else {
+      Task tk = new Task(validTaskTitle,
+        aid: taskParent.aid,
+        description: taskDescription,
+        dueDate: formattedDueDate,
+        location: taskLocation);
+      db.insertTask(tk);
+    }
 
     initializeAddTaskStreams();
   }

--- a/client/src/arcplanner/lib/src/model/task.dart
+++ b/client/src/arcplanner/lib/src/model/task.dart
@@ -33,7 +33,8 @@ class Task {
   ///   of the Task. The default is null
   /// @param location an optional parameter representing the location where
   ///   task is to be completed. The default is null
-  Task(this._aid, this._title, {description, dueDate, timeDue, location}) {
+  Task(this._title, {aid, description, dueDate, timeDue, location}) {
+    this._aid = aid;
     this._tid = new Uuid().v4();
     this._description = description;
     this._dueDate = dueDate;
@@ -50,8 +51,9 @@ class Task {
   ///   of the Task. The default is null
   /// @param location an optional parameter representing the location where
   ///   task is to be completed. The default is null
-  Task.read(this._tid, this._aid, this._title, 
-      {description, dueDate, location, timeDue, completed}) {
+  Task.read(this._tid, this._title, 
+      {aid, description, dueDate, location, timeDue, completed}) {
+    this._aid = aid;
     this._description = description;
     this._dueDate = dueDate;
     this._timeDue = timeDue;

--- a/client/src/arcplanner/lib/src/ui/add_task_screen.dart
+++ b/client/src/arcplanner/lib/src/ui/add_task_screen.dart
@@ -147,7 +147,7 @@ Widget descriptionField(){
     stream: bloc.arcParentFieldStream,
     builder: (context, snapshot) {
       return Text(
-        snapshot.hasData? snapshot.data.title : "Parent (required)",
+        snapshot.hasData? snapshot.data.title : "Parent",
         style: TextStyle(
           fontSize: 16,
           color: Colors.black

--- a/client/src/arcplanner/lib/src/ui/task_screen.dart
+++ b/client/src/arcplanner/lib/src/ui/task_screen.dart
@@ -34,7 +34,7 @@ class TaskScreen extends StatelessWidget {
         margin: EdgeInsets.only(left: 10.0, right: 10.0),
         child: StreamBuilder(
           stream: bloc.taskStream,
-          initialData: new Task('', ''),
+          initialData: new Task(''),
           builder: (context, snapshot) {
             return  ListView(
               children:[


### PR DESCRIPTION
This PR changes tasks so the Arc Parent is no longer needed to make the task. So now the only required field is the title. This works but brings the question up on whether these tasks without parents should be in the arc view (they aren't currently)? They would be in the area of Master Arcs since they have no parents. In our current build they would be the only objects not able to be seen in the arc view screen. However, I do think this makes sense as they are not part of any arc. I would love to hear some others opinions about this.