### PR TITLE
Update calendar view

### DIFF
--- a/client/src/arcplanner/lib/src/blocs/bloc.dart
+++ b/client/src/arcplanner/lib/src/blocs/bloc.dart
@@ -171,7 +171,7 @@ class Bloc extends Object with Validators {
       return await getItemsBetweenDates(DateTime.now().add(Duration(days: -1)).toString(),
           DateTime.now().add(Duration(days: 7)).toString());
     } else if (data['flag'] == 'getCalendarEvents') {
-      return await getItemsBetweenDates(DateTime(data['year'], data['month']).toString(), DateTime(data['year'], data['month'] + 1).toString());
+      return await getItemsBetweenDates(DateTime(data['year'], data['month']).add(Duration(days: -1)).toString(), DateTime(data['year'], data['month'] + 1).toString());
     } else if (data['flag'] == "clear") {
       return null;
     }

--- a/client/src/arcplanner/lib/src/blocs/bloc.dart
+++ b/client/src/arcplanner/lib/src/blocs/bloc.dart
@@ -126,6 +126,12 @@ class Bloc extends Object with Validators {
     _homeController.sink.add(obj);
   }
 
+  /// Inserts a dynamic object into the `calendarController` sink
+  /// @param obj any object that needs to be added to the `calendarController` sink
+  void calendarInsert(dynamic obj) {
+    _calendarController.sink.add(obj);
+  }
+
   /// Inserts a dynamic object into the `arcParentSelectViewController` sink
   /// @param obj any object that needs to be added to the `arcParentSelectViewController` sink
   void parentSelectInsert(dynamic obj) {
@@ -154,6 +160,8 @@ class Bloc extends Object with Validators {
     } else if (data['flag'] == 'getUpcomingItems') {
       return await getItemsBetweenDates(DateTime.now().toString(),
           DateTime.now().add(Duration(days: 7)).toString());
+    } else if (data['flag'] == 'getCalendarEvents') {
+      return await getItemsBetweenDates(DateTime(data['year'], data['month']).toString(), DateTime(data['year'], data['month'] + 1).toString());
     } else if (data['flag'] == "clear") {
       return null;
     }
@@ -409,6 +417,7 @@ class Bloc extends Object with Validators {
     _arcViewController.close();
     _taskViewController.close();
     _homeController.close();
+    _calendarController.close();
     _arcParentSelectViewController.close();
 
     // Close Add Arc Screen streams

--- a/client/src/arcplanner/lib/src/blocs/bloc.dart
+++ b/client/src/arcplanner/lib/src/blocs/bloc.dart
@@ -168,7 +168,7 @@ class Bloc extends Object with Validators {
       Arc parent = getFromMap(data['object']);
       return await getChildren(parent.parentArc);
     } else if (data['flag'] == 'getUpcomingItems') {
-      return await getItemsBetweenDates(DateTime.now().toString(),
+      return await getItemsBetweenDates(DateTime.now().add(Duration(days: -1)).toString(),
           DateTime.now().add(Duration(days: 7)).toString());
     } else if (data['flag'] == 'getCalendarEvents') {
       return await getItemsBetweenDates(DateTime(data['year'], data['month']).add(Duration(days: -1)).toString(), DateTime(data['year'], data['month'] + 1).toString());

--- a/client/src/arcplanner/lib/src/blocs/bloc.dart
+++ b/client/src/arcplanner/lib/src/blocs/bloc.dart
@@ -171,7 +171,7 @@ class Bloc extends Object with Validators {
       return await getItemsBetweenDates(DateTime.now().toString(),
           DateTime.now().add(Duration(days: 7)).toString());
     } else if (data['flag'] == 'getCalendarEvents') {
-      return await getItemsBetweenDates(DateTime(data['year'], data['month']).toString(), DateTime(data['year'], data['month'] + 1).toString());
+      return await getItemsBetweenDates(DateTime(data['year'], data['month']).add(Duration(days: -1)).toString(), DateTime(data['year'], data['month'] + 1).toString());
     } else if (data['flag'] == "clear") {
       return null;
     }

--- a/client/src/arcplanner/lib/src/blocs/bloc.dart
+++ b/client/src/arcplanner/lib/src/blocs/bloc.dart
@@ -171,7 +171,7 @@ class Bloc extends Object with Validators {
       return await getItemsBetweenDates(DateTime.now().add(Duration(days: -1)).toString(),
           DateTime.now().add(Duration(days: 7)).toString());
     } else if (data['flag'] == 'getCalendarEvents') {
-      return await getItemsBetweenDates(DateTime(data['year'], data['month']).add(Duration(days: -1)).toString(), DateTime(data['year'], data['month'] + 1).toString());
+      return await getItemsBetweenDates(DateTime(data['year'], data['month']).toString(), DateTime(data['year'], data['month'] + 1).toString());
     } else if (data['flag'] == "clear") {
       return null;
     }

--- a/client/src/arcplanner/lib/src/blocs/bloc.dart
+++ b/client/src/arcplanner/lib/src/blocs/bloc.dart
@@ -31,6 +31,7 @@ class Bloc extends Object with Validators {
   // Create streams and getters for views to interact with
   final _arcViewController = StreamController<dynamic>.broadcast();
   final _homeController = StreamController<dynamic>.broadcast();
+  final _calendarController = StreamController<dynamic>.broadcast();
 
   // Create streams and getters for parent selection view
   final _arcParentSelectViewController = StreamController<dynamic>.broadcast();
@@ -40,6 +41,9 @@ class Bloc extends Object with Validators {
   final _arcEndDateFieldController = BehaviorSubject<String>();
   final _arcDescriptionFieldController = BehaviorSubject<String>();
   final _arcParentFieldController = BehaviorSubject<Arc>();
+
+  Stream<dynamic> get calendarStream => 
+      _calendarController.stream.map(transformData);
 
   Stream<dynamic> get arcViewStream =>
       _arcViewController.stream.map(transformData);

--- a/client/src/arcplanner/lib/src/blocs/bloc.dart
+++ b/client/src/arcplanner/lib/src/blocs/bloc.dart
@@ -15,7 +15,6 @@
 import 'dart:async';
 import '../model/arc.dart';
 import '../model/task.dart';
-import '../model/user.dart';
 import '../util/databaseHelper.dart';
 import '../blocs/validators.dart';
 import 'package:rxdart/rxdart.dart';

--- a/client/src/arcplanner/lib/src/blocs/bloc.dart
+++ b/client/src/arcplanner/lib/src/blocs/bloc.dart
@@ -171,7 +171,7 @@ class Bloc extends Object with Validators {
       return await getItemsBetweenDates(DateTime.now().add(Duration(days: -1)).toString(),
           DateTime.now().add(Duration(days: 7)).toString());
     } else if (data['flag'] == 'getCalendarEvents') {
-      return await getItemsBetweenDates(DateTime(data['year'], data['month']).add(Duration(days: -1)).toString(), DateTime(data['year'], data['month'] + 1).toString());
+      return await getItemsBetweenDates(DateTime(data['year'], data['month'] - 1).add(Duration(days: -1)).toString(), DateTime(data['year'], data['month'] + 2).add(Duration(days: 1)).toString());
     } else if (data['flag'] == "clear") {
       return null;
     }

--- a/client/src/arcplanner/lib/src/helpers/date.dart
+++ b/client/src/arcplanner/lib/src/helpers/date.dart
@@ -58,20 +58,18 @@ Future<List<dynamic>> getItemsBetweenDates(String fromDate, String toDate) async
 ///   will return false
 bool checkIfDateRangeInMap(String fromDate, String toDate) {
   DateTime date = DateTime.parse(fromDate);
-  DateTime dayAfterEndDate = (DateTime.parse(toDate)).add(Duration(days:1));
-  bool dateMissingInMap = false;
+  DateTime dayAfterEndDate = (DateTime.parse(toDate));
+
   while (date.isBefore(dayAfterEndDate)) {
+    print('           DATE: $date');
+    print('DAYAFTERENDDATE: $dayAfterEndDate');
     if (!loadedDates.containsKey(formatter.format(date))) {
-      dateMissingInMap = true;
-      break;
+      return false;
     }
-    date.add(Duration(days:1));
+    date = date.add(Duration(days: 1));
   }
-  
-  if (dateMissingInMap)
-    return false;
-  else
-    return true;
+
+  return true;
 }
 
 /// Adds map to the `loadedDates` object 

--- a/client/src/arcplanner/lib/src/helpers/date.dart
+++ b/client/src/arcplanner/lib/src/helpers/date.dart
@@ -28,8 +28,8 @@ Future<List<dynamic>> getItemsBetweenDates(String fromDate, String toDate) async
   
   if (checkIfDateRangeInMap(fromDate, toDate)) {
     DateTime date = DateTime.parse(fromDate);
-    DateTime dayAfterEndDate = (DateTime.parse(toDate)).add(Duration(days:1));
-    while (date.isBefore(dayAfterEndDate)) {
+    DateTime dayAfterEndDate = (DateTime.parse(toDate)).add(Duration(days: 1));
+    while (date.isBefore(dayAfterEndDate) || date.isAtSameMomentAs(dayAfterEndDate)) {
       List<String> uuids = loadedDates[formatter.format(date)];
       for (String uuid in uuids) {
         upcomingItems.add(bloc.getFromMap(uuid));

--- a/client/src/arcplanner/lib/src/helpers/date.dart
+++ b/client/src/arcplanner/lib/src/helpers/date.dart
@@ -61,8 +61,6 @@ bool checkIfDateRangeInMap(String fromDate, String toDate) {
   DateTime dayAfterEndDate = (DateTime.parse(toDate));
 
   while (date.isBefore(dayAfterEndDate)) {
-    print('           DATE: $date');
-    print('DAYAFTERENDDATE: $dayAfterEndDate');
     if (!loadedDates.containsKey(formatter.format(date))) {
       return false;
     }

--- a/client/src/arcplanner/lib/src/helpers/tile.dart
+++ b/client/src/arcplanner/lib/src/helpers/tile.dart
@@ -1,0 +1,32 @@
+/** 
+ *  Team CGKM - Matthew Chastain, Justin Grabowski, Kevin Kelly, Jonathan Middleton
+ *  CS298 Spring 2019 
+ *
+ *  Authors: 
+ *    Primary: Matthew Chastain
+ *    Contributors: 
+ * 
+ *  Provided as is. No warranties expressed or implied. Use at your own risk.
+ *
+ *  This file contains the generic tile Widget present in many screens in the 
+ *  application. It can be used to build either Arc Tiles or Task Tiles.
+ */
+
+import 'package:flutter/material.dart';
+import '../model/arc.dart';
+import '../model/task.dart';
+import '../ui/arc_tile.dart';
+import '../ui/task_tile.dart';
+
+/// Build method for the tile object
+/// @param obj Arc or Task to build
+/// @param context BuildContext for tile object
+Widget tile(dynamic obj, BuildContext context) {
+  if (obj is Arc) {
+    return arcTile(obj, context);
+  } else if (obj is Task) {
+    return taskTile(obj, context);
+  } else {
+    return Text('tile tried to build not an Arc or Task');
+  }
+}

--- a/client/src/arcplanner/lib/src/model/arc.dart
+++ b/client/src/arcplanner/lib/src/model/arc.dart
@@ -38,7 +38,13 @@ class Arc {
     this._aid = new Uuid().v4();
     this._description = description;
     this._dueDate = dueDate;
-    this._timeDue = timeDue;
+
+    if (timeDue == null) {
+      timeDue = '23:59:59';
+    } else {
+      this._timeDue = timeDue;
+    }
+    
     this._parentArc = parentArc;
     this._completed = false;
   }
@@ -60,7 +66,13 @@ class Arc {
       {description, dueDate, timeDue, parentArc, completed, childrenUUIDs}) {
     this._description = description;
     this._dueDate = dueDate;
-    this._timeDue = timeDue;
+
+    if (timeDue == null) {
+      timeDue = '23:59:59';
+    } else {
+      this._timeDue = timeDue;
+    }
+
     this._parentArc = parentArc;
     this.childrenUUIDs = childrenUUIDs?.split(",");
     if (completed == '1') {
@@ -76,6 +88,7 @@ class Arc {
   String get title => _title;
   String get description => _description;
   String get dueDate => _dueDate;
+  String get timeDue => _timeDue;
   String get parentArc => _parentArc;
   bool get completed => _completed;
 

--- a/client/src/arcplanner/lib/src/model/task.dart
+++ b/client/src/arcplanner/lib/src/model/task.dart
@@ -37,7 +37,13 @@ class Task {
     this._tid = new Uuid().v4();
     this._description = description;
     this._dueDate = dueDate;
-    this._timeDue = timeDue;
+
+    if (timeDue == null) {
+      timeDue = '23:59:59';
+    } else {
+      this._timeDue = timeDue;
+    }
+    
     this._location = location;
     this._completed = false;
   }
@@ -54,7 +60,13 @@ class Task {
       {description, dueDate, location, timeDue, completed}) {
     this._description = description;
     this._dueDate = dueDate;
-    this._timeDue = timeDue;
+
+    if (timeDue == null) {
+      timeDue = '23:59:59';
+    } else {
+      this._timeDue = timeDue;
+    }
+
     this._location = location;
     if (completed == 'true') {
       this._completed = true;
@@ -69,6 +81,7 @@ class Task {
   String get title => _title;
   String get description => _description;
   String get dueDate => _dueDate;
+  String get timeDue => _timeDue;
   String get location => _location;
   bool get completed => _completed;
 

--- a/client/src/arcplanner/lib/src/ui/calendar_screen.dart
+++ b/client/src/arcplanner/lib/src/ui/calendar_screen.dart
@@ -88,10 +88,7 @@ class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixi
     _events.clear();
     _loadedEvents.clear();
     
-    // reloads the UI
     setState(() {});
-
-    _updateFromStream(_month, _year);
   }
 
   @override
@@ -116,17 +113,17 @@ class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixi
                 return new FutureBuilder(
                   future: snapshot.data,
                   builder: (context, snapshot) {
-                    print('got back here fucko');
-
                     if (firstTimeLoading) {
                       _updateFromStream(_month, _year);
                       firstTimeLoading = false;
                     }
 
-                    if (snapshot.hasData) {
-                      dynamic snapshotData = snapshot.data;
+                    if (snapshot.connectionState == ConnectionState.done) {
+                      
+                      List<dynamic> snapshotData = snapshot.data;
 
                       if (snapshotData.toString() != '[]') {
+
                         // adding objects from stream into _loadedEvents
                         for (dynamic obj in snapshotData) {
                           if (!_isInLoadedEvents(obj)) {
@@ -142,12 +139,21 @@ class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixi
                           }
                         }
 
+                        _loadedEvents.removeWhere((String key, dynamic obj) {
+                          return DateTime.parse(obj.dueDate).month != _month;
+                        });
+
                         _updateDayEvents();
                         
                         print('DAY EVENTS');
                         print(_dayEvents);
                         print('LOADED EVENTS');
                         print(_loadedEvents);
+
+                        if (firstTimeLoading) {
+                          _updateFromStream(_month, _year);
+                          firstTimeLoading = false;
+                        }
 
                         if (_dayEvents.isNotEmpty) {
                           _populateBuildList();
@@ -164,7 +170,7 @@ class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixi
                         return _noItemsWidget();
                       }
                     } else {
-                      return Container();
+                      return _noItemsWidget();
                     }
                   },
                 );
@@ -256,6 +262,8 @@ class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixi
 
   // More advanced TableCalendar configuration (using Builders & Styles)
   Widget _buildTableCalendarWithBuilders() {
+    print('CALLING BUILD METHOD');
+
     return TableCalendar(
       locale: 'en_US',
       events: _visibleEvents,

--- a/client/src/arcplanner/lib/src/ui/calendar_screen.dart
+++ b/client/src/arcplanner/lib/src/ui/calendar_screen.dart
@@ -78,9 +78,6 @@ class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixi
 
     _year = first.year;
     _month = first.month;
-    
-    print('year: $_year');
-    print('month: $_month');
 
     _selectedDay = first;
     _selectedEvents.clear();
@@ -144,11 +141,6 @@ class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixi
                         });
 
                         _updateDayEvents();
-                        
-                        print('DAY EVENTS');
-                        print(_dayEvents);
-                        print('LOADED EVENTS');
-                        print(_loadedEvents);
 
                         if (firstTimeLoading) {
                           _updateFromStream(_month, _year);

--- a/client/src/arcplanner/lib/src/ui/calendar_screen.dart
+++ b/client/src/arcplanner/lib/src/ui/calendar_screen.dart
@@ -3,14 +3,16 @@
  *  CS298 Spring 2019 
  *
  *  Authors: 
- *    Primary: Kevin Kelly
+ *    Primary: Matthew Chastain, Kevin Kelly
  *    Contributors: 
  * 
  *  Provided as is. No warranties expressed or implied. Use at your own risk.
  *
- *  This file contains ArcPlanner's home screen which will be displayed on 
- *  launch. The screen shows users a list of upcoming tasks along with a Task 
- *  quick-add button.
+ *  This file contains ArcPlanner's Calendar Screen which displays an on-screen 
+ *  Calendar which can be scrolled for different months. Below the Calendar is a
+ *  list of Arcs or Tasks that are set to be due on the selected day. Due to the 
+ *  scrolling nature of the Calendar, it is implemented as a exention of a 
+ *  StatefulWidget.
  */
 
 import 'package:flutter/material.dart';
@@ -18,9 +20,7 @@ import 'package:table_calendar/table_calendar.dart';
 import 'package:date_utils/date_utils.dart';
 import 'drawer_menu.dart';
 import '../blocs/bloc.dart';
-import 'arc_tile.dart';
-import 'task_tile.dart';
-import '../model/arc.dart';
+import '../helpers/tile.dart';
 import '../model/task.dart';
 
 class CalendarScreen extends StatefulWidget {
@@ -42,7 +42,7 @@ class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixi
   AnimationController _controller;
   List<dynamic> snapshotData;
 
-
+  /// Establishes initial state of the Calendar Screen
   @override
   void initState() {    
     super.initState();
@@ -62,7 +62,9 @@ class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixi
     // _controller.forward();
   }
 
-
+  /// Changes the selected date in response to user event
+  /// @param day the day selected by the user
+  /// @param events list of events associated with that day
   void _onDaySelected(DateTime day, List events) {
     setState(() {
       _selectedDay = day;
@@ -70,12 +72,17 @@ class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixi
     });
   }
 
-
+  /// Sends information to `bloc.dart` through bloc.calendarStream
+  /// @param month month to retrieve items for
+  /// @param year year to retrieve items for 
   void _updateFromStream(int month, int year) {
     bloc.calendarInsert({'month': month,'year': year, 'flag': 'getCalendarEvents'});
   }
 
-
+  /// Changes the current calendar view in response to user event
+  /// @param first the first day of new calendar view
+  /// @param last the last day of new calendar view
+  /// @param format the formatting of the calendar view
   void _onVisibleDaysChanged(DateTime first, DateTime last, CalendarFormat format) {
     _year = first.year;
     _month = first.month;
@@ -89,7 +96,8 @@ class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixi
     setState(() {});
   }
 
-
+  /// Build method for the Calendar Screen
+  /// @param context BuildContext for Calendar Screen
   @override
   Widget build(BuildContext context) {
     bool firstTimeLoading = true;
@@ -162,7 +170,7 @@ class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixi
     );
   }
 
-
+  /// Builds the list of items to display below the on-screen Calendar
   void _populateBuildList() {
     _buildList.clear();
     _dayEvents.forEach((String key, dynamic obj) {
@@ -172,7 +180,7 @@ class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixi
     //_buildList.sort((a, b) => a.timeDue.compareTo(b.timeDue));
   }
 
-
+  /// Updates the list of events occuring on the selected day
   void _updateDayEvents() {
     _dayEvents.clear();
 
@@ -186,7 +194,8 @@ class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixi
     });
   }
 
-
+  /// Checks if an obj is in the list of selected day events
+  /// @param obj Arc or Task to check for
   bool _isInDayEvents(dynamic obj) {
     if (obj is Task) {
       if (_dayEvents.containsKey(obj.tid)) {
@@ -203,7 +212,8 @@ class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixi
     }
   }
 
-
+  /// Checks if an obj is in the list of currently loaded events
+  /// @param obj Arc or Task to check for
   bool _isInLoadedEvents(dynamic obj) {
     if (obj is Task) {
       if (_loadedEvents.containsKey(obj.tid)) {
@@ -220,7 +230,7 @@ class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixi
     }
   }
 
-
+  /// Build script for 'No Arcs/Tasks' message
   Widget _noItemsWidget() {
     return Column(
       mainAxisAlignment: MainAxisAlignment.center,
@@ -236,7 +246,7 @@ class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixi
   }
 
 
-  // More advanced TableCalendar configuration (using Builders & Styles)
+  /// Build roster for TableCalendar
   Widget _buildTableCalendarWithBuilders() {
     return TableCalendar(
       locale: 'en_US',
@@ -326,7 +336,7 @@ class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixi
     );
   }
 
-
+  /// Builds the list of tiles displayed underneath the on-screen Calendar
   Widget _buildTileList() {
     if (_dayEvents.isNotEmpty) {
       _populateBuildList();
@@ -339,16 +349,5 @@ class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixi
     } else {
       return _noItemsWidget();
     }
-  }
-}
-
-
-Widget tile(dynamic obj, BuildContext context) {
-  if (obj is Arc) {
-    return arcTile(obj, context);
-  } else if (obj is Task) {
-    return taskTile(obj, context);
-  } else {
-    return Text('tile tried to build not an Arc or Task');
   }
 }

--- a/client/src/arcplanner/lib/src/ui/calendar_screen.dart
+++ b/client/src/arcplanner/lib/src/ui/calendar_screen.dart
@@ -71,6 +71,7 @@ class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixi
   void _onVisibleDaysChanged(DateTime first, DateTime last, CalendarFormat format) {
     _year = first.year;
     _month = first.month;
+    
     setState(() {
       _visibleEvents = Map.fromEntries(
         _events.entries.where(
@@ -79,6 +80,7 @@ class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixi
               entry.key.isBefore(last.add(const Duration(days: 1))),
         ),
       );
+      _selectedDay = first;
     });
   }
 
@@ -146,8 +148,20 @@ class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixi
                           );
                         }
                       } else {
-                        return Container();
+                        return Column(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: <Widget>[
+                            Text(
+                              'There are no items for this day',
+                              style: TextStyle(
+                                color: Colors.grey,
+                              ),
+                            ),
+                          ],
+                        );
                       }
+                    } else {
+                      return Container();
                     }
                   },
                 );

--- a/client/src/arcplanner/lib/src/ui/calendar_screen.dart
+++ b/client/src/arcplanner/lib/src/ui/calendar_screen.dart
@@ -116,7 +116,9 @@ class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixi
                       firstTimeLoading = false;
                     }
 
-                    if (snapshot.connectionState == ConnectionState.done) {
+                    if (snapshot.connectionState == ConnectionState.waiting) {
+                      return _buildTileList();
+                    } else if (snapshot.connectionState == ConnectionState.done) {
                       snapshotData = snapshot.data;
 
                       if (snapshotData.toString() != '[]') {
@@ -141,23 +143,12 @@ class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixi
                         });
 
                         _updateDayEvents();
-
-                        if (_dayEvents.isNotEmpty) {
-                          _populateBuildList();
-                          return ListView.builder(
-                            itemCount: _buildList.length,
-                            itemBuilder: (context, index) {
-                              return tile(_buildList[index], context);
-                            },
-                          );
-                        } else {
-                          return _noItemsWidget();
-                        }
+                        return _buildTileList();
                       } else {
                         return _noItemsWidget();
                       }
                     } else {
-                      return _noItemsWidget();
+                      return Container();
                     }
                   },
                 );
@@ -332,6 +323,20 @@ class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixi
       },
       onVisibleDaysChanged: _onVisibleDaysChanged,
     );
+  }
+
+  Widget _buildTileList() {
+    if (_dayEvents.isNotEmpty) {
+      _populateBuildList();
+      return ListView.builder(
+        itemCount: _buildList.length,
+        itemBuilder: (context, index) {
+          return tile(_buildList[index], context);
+        },
+      );
+    } else {
+      return _noItemsWidget();
+    }
   }
 }
 

--- a/client/src/arcplanner/lib/src/ui/calendar_screen.dart
+++ b/client/src/arcplanner/lib/src/ui/calendar_screen.dart
@@ -115,23 +115,26 @@ class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixi
                     if (snapshot.hasData) {
                       dynamic snapshotData = snapshot.data;
 
+                      for (dynamic obj in snapshotData) {
+                        print(obj);
+                      }
+
                       if (snapshotData.toString() != '[]') {
-                        _dayEvents.clear();
-                        _loadedEvents.clear();
+                        // _dayEvents.clear();
+                        // _loadedEvents.clear();
 
+                        // adding objects from stream into _loadedEvents
                         for (dynamic obj in snapshotData) {
-                          _loadedEvents.add(obj);
-                        }
-
-
-
-                        for (dynamic obj in _loadedEvents) {
-                          _events.addAll({DateTime.parse(obj.dueDate): ['']});
-                          if (DateTime.parse(obj.dueDate).year == _selectedDay.year && DateTime.parse(obj.dueDate).month == _selectedDay.month && DateTime.parse(obj.dueDate).day == _selectedDay.day) {
-                            _dayEvents.add(obj);
+                          if (_loadedEvents.contains(obj)) {
+                            // _loadedEvents.add(obj);
+                          } else {
+                            _loadedEvents.add(obj);
                           }
                         }
 
+
+                        _updateEvents();
+                        
                         //_dayEvents.sort((a, b) => a.timeDue.compareTo(b.timeDue));
 
                         if (_dayEvents.isNotEmpty) {
@@ -142,30 +145,10 @@ class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixi
                             },
                           );
                         } else {
-                          return Column(
-                            mainAxisAlignment: MainAxisAlignment.center,
-                            children: <Widget>[
-                              Text(
-                                'There are no items for this day',
-                                style: TextStyle(
-                                  color: Colors.grey,
-                                ),
-                              ),
-                            ],
-                          );
+                          return _noItemsWidget();
                         }
                       } else {
-                        return Column(
-                          mainAxisAlignment: MainAxisAlignment.center,
-                          children: <Widget>[
-                            Text(
-                              'There are no items for this day',
-                              style: TextStyle(
-                                color: Colors.grey,
-                              ),
-                            ),
-                          ],
-                        );
+                        return _noItemsWidget();
                       }
                     } else {
                       return Container();
@@ -179,6 +162,33 @@ class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixi
       ),
       
       drawer: drawerMenu(context)
+    );
+  }
+
+  // Takes the Arcs/Tasks in _loadedEvents and adds them to the _events List
+  void _updateEvents() {
+    _dayEvents.clear();
+    for (dynamic obj in _loadedEvents) {
+      _events.addAll({DateTime.parse(obj.dueDate): ['']});
+      if (!_dayEvents.contains(obj) && DateTime.parse(obj.dueDate).year == _selectedDay.year && DateTime.parse(obj.dueDate).month == _selectedDay.month && DateTime.parse(obj.dueDate).day == _selectedDay.day) {
+        _dayEvents.add(obj);
+      }
+    }
+
+    _visibleEvents = _events;
+  }
+
+  Widget _noItemsWidget() {
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: <Widget>[
+        Text(
+          'There are no items for this day',
+          style: TextStyle(
+            color: Colors.grey,
+          ),
+        ),
+      ],
     );
   }
 

--- a/client/src/arcplanner/lib/src/ui/calendar_screen.dart
+++ b/client/src/arcplanner/lib/src/ui/calendar_screen.dart
@@ -41,9 +41,7 @@ class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixi
   AnimationController _controller;
 
   @override
-  void initState() {
-    _updateFromStream();
-    
+  void initState() {    
     super.initState();
     _month = DateTime.now().month;
     _year = DateTime.now().year;
@@ -77,8 +75,6 @@ class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixi
   void _onVisibleDaysChanged(DateTime first, DateTime last, CalendarFormat format) {
     _year = first.year;
     _month = first.month;
-    
-    _updateFromStream();
     
     setState(() {
       _visibleEvents = Map.fromEntries(
@@ -134,7 +130,10 @@ class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixi
                           }
                         }
 
-                        _dayEvents.sort((a, b) => a.dueDate.compareTo(b.dueDate));
+                        _dayEvents.sort((a, b) => a.timeDue.compareTo(b.timeDue));
+
+                        _buildTableCalendarWithBuilders();
+
                         if (_dayEvents.isNotEmpty) {
                           return ListView.builder(
                             itemCount: _dayEvents.length,

--- a/client/src/arcplanner/lib/src/ui/calendar_screen.dart
+++ b/client/src/arcplanner/lib/src/ui/calendar_screen.dart
@@ -123,16 +123,16 @@ class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixi
                           _loadedEvents.add(obj);
                         }
 
+
+
                         for (dynamic obj in _loadedEvents) {
                           _events.addAll({DateTime.parse(obj.dueDate): ['']});
-                          if (DateTime.parse(obj.dueDate).compareTo(_selectedDay) == 0) {
+                          if (DateTime.parse(obj.dueDate).year == _selectedDay.year && DateTime.parse(obj.dueDate).month == _selectedDay.month && DateTime.parse(obj.dueDate).day == _selectedDay.day) {
                             _dayEvents.add(obj);
                           }
                         }
 
-                        _dayEvents.sort((a, b) => a.timeDue.compareTo(b.timeDue));
-
-                        _buildTableCalendarWithBuilders();
+                        //_dayEvents.sort((a, b) => a.timeDue.compareTo(b.timeDue));
 
                         if (_dayEvents.isNotEmpty) {
                           return ListView.builder(

--- a/client/src/arcplanner/lib/src/ui/calendar_screen.dart
+++ b/client/src/arcplanner/lib/src/ui/calendar_screen.dart
@@ -57,7 +57,7 @@ class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixi
 
     _controller = AnimationController(
       vsync: this,
-      duration: const Duration(milliseconds: 500),
+      duration: const Duration(milliseconds: 400),
     );
 
     _controller.forward();
@@ -75,7 +75,6 @@ class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixi
   }
 
   void _onVisibleDaysChanged(DateTime first, DateTime last, CalendarFormat format) {
-
     _year = first.year;
     _month = first.month;
 

--- a/client/src/arcplanner/lib/src/ui/calendar_screen.dart
+++ b/client/src/arcplanner/lib/src/ui/calendar_screen.dart
@@ -35,23 +35,7 @@ class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixi
   void initState() {
     super.initState();
     _selectedDay = DateTime.now();
-    _events = {
-      _selectedDay.subtract(Duration(days: 30)): ['Event A0', 'Event B0', 'Event C0'],
-      _selectedDay.subtract(Duration(days: 27)): ['Event A1'],
-      _selectedDay.subtract(Duration(days: 20)): ['Event A2', 'Event B2', 'Event C2', 'Event D2'],
-      _selectedDay.subtract(Duration(days: 16)): ['Event A3', 'Event B3'],
-      _selectedDay.subtract(Duration(days: 10)): ['Event A4', 'Event B4', 'Event C4'],
-      _selectedDay.subtract(Duration(days: 4)): ['Event A5', 'Event B5', 'Event C5'],
-      _selectedDay.subtract(Duration(days: 2)): ['Event A6', 'Event B6'],
-      _selectedDay: ['Event A7', 'Event B7', 'Event C7', 'Event D7'],
-      _selectedDay.add(Duration(days: 1)): ['Event A8', 'Event B8', 'Event C8', 'Event D8'],
-      _selectedDay.add(Duration(days: 3)): Set.from(['Event A9', 'Event A9', 'Event B9']).toList(),
-      _selectedDay.add(Duration(days: 7)): ['Event A10', 'Event B10', 'Event C10'],
-      _selectedDay.add(Duration(days: 11)): ['Event A11', 'Event B11'],
-      _selectedDay.add(Duration(days: 17)): ['Event A12', 'Event B12', 'Event C12', 'Event D12'],
-      _selectedDay.add(Duration(days: 22)): ['Event A13', 'Event B13'],
-      _selectedDay.add(Duration(days: 26)): ['Event A14', 'Event B14', 'Event C14'],
-    };
+    _events = {};
 
     _selectedEvents = _events[_selectedDay] ?? [];
     _visibleEvents = _events;
@@ -197,19 +181,17 @@ class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixi
 
   Widget _buildEventList() {
     return ListView(
-      children: _selectedEvents
-          .map((event) => Container(
-                decoration: BoxDecoration(
-                  border: Border.all(width: 0.8),
-                  borderRadius: BorderRadius.circular(12.0),
-                ),
-                margin: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 4.0),
-                child: ListTile(
-                  title: Text(event.toString()),
-                  onTap: () => print('$event tapped!'),
-                ),
-              ))
-          .toList(),
+      children: _selectedEvents.map((event) => Container(
+        decoration: BoxDecoration(
+          border: Border.all(width: 0.8),
+          borderRadius: BorderRadius.circular(12.0),
+        ),
+        margin: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 4.0),
+        child: ListTile(
+          title: Text(event.toString()),
+          onTap: () => print('$event tapped!'),
+        ),
+      )).toList(),
     );
   }
 }

--- a/client/src/arcplanner/lib/src/ui/calendar_screen.dart
+++ b/client/src/arcplanner/lib/src/ui/calendar_screen.dart
@@ -30,6 +30,8 @@ class CalendarScreen extends StatefulWidget {
 
 class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixin { 
 
+  List<dynamic> _loadedEvents;
+  List<dynamic> _dayEvents;
   int _month;
   int _year;
   DateTime _selectedDay;
@@ -45,6 +47,8 @@ class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixi
     _year = DateTime.now().year;
     _selectedDay = DateTime.now();
     _events = {};
+    _loadedEvents = [];
+    _dayEvents = [];
 
     _selectedEvents = _events[_selectedDay] ?? [];
     _visibleEvents = _events;
@@ -82,7 +86,6 @@ class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixi
   Widget build(BuildContext context) {
     bool firstTimeLoading = true;
 
-
     return Scaffold(
       appBar: AppBar(
         title: Text("Calendar"),
@@ -106,31 +109,47 @@ class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixi
 
                     if (snapshot.hasData) {
                       dynamic snapshotData = snapshot.data;
-                      if (snapshotData.toString() != '[]') {
-                        return ListView.builder(
-                          itemCount: snapshotData.length,
-                          itemBuilder: (context, index) {
-                            return tile(snapshotData[index], context);
-                          },
-                        );
-                      } else {
-                        return Column(
-                          mainAxisAlignment: MainAxisAlignment.center,
-                          children: <Widget>[
-                            Text(
-                              'There are no items for this day',
-                              style: TextStyle(
-                                color: Colors.grey,
-                              ),
-                            ),
 
-                          ],
-                        );
+                      if (snapshotData.toString() != '[]') {
+                        _dayEvents.clear();
+                        _loadedEvents.clear();
+
+                        for (dynamic obj in snapshotData) {
+                          _loadedEvents.add(obj);
+                        }
+
+                        for (dynamic obj in _loadedEvents) {
+                          if (DateTime.parse(obj.dueDate).compareTo(_selectedDay) == 0) {
+                            _dayEvents.add(obj);
+                          }
+                        }
+
+                        _dayEvents.sort((a, b) => a.dueDate.compareTo(b.dueDate));
+                        if (_dayEvents.isNotEmpty) {
+                          return ListView.builder(
+                            itemCount: _dayEvents.length,
+                            itemBuilder: (context, index) {
+                              return tile(_dayEvents[index], context);
+                            },
+                          );
+                        } else {
+                          return Column(
+                            mainAxisAlignment: MainAxisAlignment.center,
+                            children: <Widget>[
+                              Text(
+                                'There are no items for this day',
+                                style: TextStyle(
+                                  color: Colors.grey,
+                                ),
+                              ),
+                            ],
+                          );
+                        }
+                      } else {
+                        return Container();
                       }
-                    } else {
-                      return Container();
                     }
-                  }
+                  },
                 );
               }
             ),

--- a/client/src/arcplanner/lib/src/ui/calendar_screen.dart
+++ b/client/src/arcplanner/lib/src/ui/calendar_screen.dart
@@ -70,16 +70,25 @@ class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixi
     });
   }
 
-  void _updateFromStream() {
-    bloc.calendarInsert({'month': _month,'year': _year, 'flag': 'getCalendarEvents'});
+  void _updateFromStream(int month, int year) {
+    bloc.calendarInsert({'month': month,'year': year, 'flag': 'getCalendarEvents'});
   }
 
   void _onVisibleDaysChanged(DateTime first, DateTime last, CalendarFormat format) {
+    _year = first.year;
+    print('year: $_year');
+    _month = first.month;
+    print('month: $_month');
+
+    _events.clear();
     _loadedEvents.clear();
+    _updateFromStream(_month, _year);
     _updateEvents();
     
-    _year = first.year;
-    _month = first.month;
+    print('DAY EVENTS');
+    print(_dayEvents);
+    print('LOADED EVENTS');
+    print(_loadedEvents);    
     
     setState(() {
       _visibleEvents = Map.fromEntries(
@@ -115,7 +124,7 @@ class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixi
                   future: snapshot.data,
                   builder: (context, snapshot) {
                     if (firstTimeLoading) {
-                      _updateFromStream();
+                      _updateFromStream(_month, _year);
                       firstTimeLoading = false;
                     }
 
@@ -126,6 +135,10 @@ class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixi
                         // adding objects from stream into _loadedEvents
                         for (dynamic obj in snapshotData) {
                           if (!_isInLoadedEvents(obj)) {
+                            if (_events[DateTime.parse(obj.dueDate)] == null) {
+                              _events[DateTime.parse(obj.dueDate)] = [];
+                            }
+                            _events[DateTime.parse(obj.dueDate)].add(obj);
                             if (obj is Task) {
                               _loadedEvents.addAll({obj.tid: obj});
                             } else {

--- a/client/src/arcplanner/lib/src/ui/calendar_screen.dart
+++ b/client/src/arcplanner/lib/src/ui/calendar_screen.dart
@@ -75,6 +75,9 @@ class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixi
   }
 
   void _onVisibleDaysChanged(DateTime first, DateTime last, CalendarFormat format) {
+    _loadedEvents.clear();
+    _updateEvents();
+    
     _year = first.year;
     _month = first.month;
     
@@ -95,6 +98,7 @@ class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixi
 
     return Scaffold(
       appBar: AppBar(
+        centerTitle: true,
         title: Text("Calendar"),
       ),
       
@@ -130,7 +134,7 @@ class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixi
                           }
                         }
 
-                        //_updateEvents();
+                        _updateEvents();
 
                         if (_dayEvents.isNotEmpty) {
                           _populateBuildList();

--- a/client/src/arcplanner/lib/src/ui/calendar_screen.dart
+++ b/client/src/arcplanner/lib/src/ui/calendar_screen.dart
@@ -40,8 +40,8 @@ class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixi
   Map<DateTime, List> _visibleEvents;
   List _selectedEvents;
   AnimationController _controller;
-
   List<dynamic> snapshotData;
+
 
   @override
   void initState() {    
@@ -53,17 +53,15 @@ class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixi
     _loadedEvents = Map<String, dynamic>();
     _dayEvents = Map<String, dynamic>();
     _buildList = List<dynamic>();
-
     _selectedEvents = _events[_selectedDay] ?? [];
     _visibleEvents = _events;
-
     _controller = AnimationController(
       vsync: this,
       duration: const Duration(milliseconds: 400),
     );
-
-    _controller.forward();
+    // _controller.forward();
   }
+
 
   void _onDaySelected(DateTime day, List events) {
     setState(() {
@@ -72,9 +70,11 @@ class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixi
     });
   }
 
+
   void _updateFromStream(int month, int year) {
     bloc.calendarInsert({'month': month,'year': year, 'flag': 'getCalendarEvents'});
   }
+
 
   void _onVisibleDaysChanged(DateTime first, DateTime last, CalendarFormat format) {
     _year = first.year;
@@ -88,6 +88,7 @@ class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixi
     
     setState(() {});
   }
+
 
   @override
   Widget build(BuildContext context) {
@@ -122,7 +123,6 @@ class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixi
                       snapshotData = snapshot.data;
 
                       if (snapshotData.toString() != '[]') {
-
                         // adding objects from stream into _loadedEvents
                         for (dynamic obj in snapshotData) {
                           if (!_isInLoadedEvents(obj)) {
@@ -162,6 +162,7 @@ class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixi
     );
   }
 
+
   void _populateBuildList() {
     _buildList.clear();
     _dayEvents.forEach((String key, dynamic obj) {
@@ -171,7 +172,7 @@ class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixi
     //_buildList.sort((a, b) => a.timeDue.compareTo(b.timeDue));
   }
 
-  // Takes the Arcs/Tasks in _loadedEvents and adds them to the _events List
+
   void _updateDayEvents() {
     _dayEvents.clear();
 
@@ -183,11 +184,8 @@ class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixi
         _dayEvents.addAll({key: obj});
       }
     });
-
-    _visibleEvents = _events;
-
-    _controller.forward(from: 0.0);
   }
+
 
   bool _isInDayEvents(dynamic obj) {
     if (obj is Task) {
@@ -205,6 +203,7 @@ class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixi
     }
   }
 
+
   bool _isInLoadedEvents(dynamic obj) {
     if (obj is Task) {
       if (_loadedEvents.containsKey(obj.tid)) {
@@ -221,6 +220,7 @@ class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixi
     }
   }
 
+
   Widget _noItemsWidget() {
     return Column(
       mainAxisAlignment: MainAxisAlignment.center,
@@ -234,6 +234,7 @@ class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixi
       ],
     );
   }
+
 
   // More advanced TableCalendar configuration (using Builders & Styles)
   Widget _buildTableCalendarWithBuilders() {
@@ -325,6 +326,7 @@ class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixi
     );
   }
 
+
   Widget _buildTileList() {
     if (_dayEvents.isNotEmpty) {
       _populateBuildList();
@@ -339,6 +341,7 @@ class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixi
     }
   }
 }
+
 
 Widget tile(dynamic obj, BuildContext context) {
   if (obj is Arc) {

--- a/client/src/arcplanner/lib/src/ui/calendar_screen.dart
+++ b/client/src/arcplanner/lib/src/ui/calendar_screen.dart
@@ -41,6 +41,8 @@ class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixi
   List _selectedEvents;
   AnimationController _controller;
 
+  List<dynamic> snapshotData;
+
   @override
   void initState() {    
     super.initState();
@@ -115,8 +117,7 @@ class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixi
                     }
 
                     if (snapshot.connectionState == ConnectionState.done) {
-                      
-                      List<dynamic> snapshotData = snapshot.data;
+                      snapshotData = snapshot.data;
 
                       if (snapshotData.toString() != '[]') {
 
@@ -140,11 +141,6 @@ class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixi
                         });
 
                         _updateDayEvents();
-
-                        if (firstTimeLoading) {
-                          _updateFromStream(_month, _year);
-                          firstTimeLoading = false;
-                        }
 
                         if (_dayEvents.isNotEmpty) {
                           _populateBuildList();
@@ -186,9 +182,6 @@ class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixi
 
   // Takes the Arcs/Tasks in _loadedEvents and adds them to the _events List
   void _updateDayEvents() {
-
-    print('ENTERING _updateEvents');
-
     _dayEvents.clear();
 
     _loadedEvents.forEach((String key, dynamic obj) {
@@ -253,8 +246,6 @@ class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixi
 
   // More advanced TableCalendar configuration (using Builders & Styles)
   Widget _buildTableCalendarWithBuilders() {
-    print('CALLING BUILD METHOD');
-
     return TableCalendar(
       locale: 'en_US',
       events: _visibleEvents,

--- a/client/src/arcplanner/lib/src/ui/calendar_screen.dart
+++ b/client/src/arcplanner/lib/src/ui/calendar_screen.dart
@@ -42,6 +42,8 @@ class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixi
 
   @override
   void initState() {
+    _updateFromStream();
+    
     super.initState();
     _month = DateTime.now().month;
     _year = DateTime.now().year;
@@ -68,9 +70,15 @@ class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixi
     });
   }
 
+  void _updateFromStream() {
+    bloc.calendarInsert({'month': _month,'year': _year, 'flag': 'getCalendarEvents'});
+  }
+
   void _onVisibleDaysChanged(DateTime first, DateTime last, CalendarFormat format) {
     _year = first.year;
     _month = first.month;
+    
+    _updateFromStream();
     
     setState(() {
       _visibleEvents = Map.fromEntries(
@@ -80,7 +88,6 @@ class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixi
               entry.key.isBefore(last.add(const Duration(days: 1))),
         ),
       );
-      _selectedDay = first;
     });
   }
 
@@ -105,7 +112,7 @@ class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixi
                   future: snapshot.data,
                   builder: (context, snapshot) {
                     if (firstTimeLoading) {
-                      bloc.calendarInsert({'month': _month,'year': _year, 'flag': 'getCalendarEvents'});
+                      _updateFromStream();
                       firstTimeLoading = false;
                     }
 
@@ -121,6 +128,7 @@ class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixi
                         }
 
                         for (dynamic obj in _loadedEvents) {
+                          _events.addAll({DateTime.parse(obj.dueDate): ['']});
                           if (DateTime.parse(obj.dueDate).compareTo(_selectedDay) == 0) {
                             _dayEvents.add(obj);
                           }

--- a/client/src/arcplanner/lib/src/ui/calendar_screen.dart
+++ b/client/src/arcplanner/lib/src/ui/calendar_screen.dart
@@ -57,7 +57,7 @@ class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixi
 
     _controller = AnimationController(
       vsync: this,
-      duration: const Duration(milliseconds: 400),
+      duration: const Duration(milliseconds: 500),
     );
 
     _controller.forward();
@@ -75,30 +75,23 @@ class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixi
   }
 
   void _onVisibleDaysChanged(DateTime first, DateTime last, CalendarFormat format) {
+
     _year = first.year;
-    print('year: $_year');
     _month = first.month;
+    
+    print('year: $_year');
     print('month: $_month');
 
+    _selectedDay = first;
+    _selectedEvents.clear();
+    _visibleEvents.clear();
     _events.clear();
     _loadedEvents.clear();
+    
+    // reloads the UI
+    setState(() {});
+
     _updateFromStream(_month, _year);
-    _updateEvents();
-    
-    print('DAY EVENTS');
-    print(_dayEvents);
-    print('LOADED EVENTS');
-    print(_loadedEvents);    
-    
-    setState(() {
-      _visibleEvents = Map.fromEntries(
-        _events.entries.where(
-          (entry) =>
-              entry.key.isAfter(first.subtract(const Duration(days: 1))) &&
-              entry.key.isBefore(last.add(const Duration(days: 1))),
-        ),
-      );
-    });
   }
 
   @override
@@ -123,6 +116,8 @@ class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixi
                 return new FutureBuilder(
                   future: snapshot.data,
                   builder: (context, snapshot) {
+                    print('got back here fucko');
+
                     if (firstTimeLoading) {
                       _updateFromStream(_month, _year);
                       firstTimeLoading = false;
@@ -147,7 +142,12 @@ class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixi
                           }
                         }
 
-                        _updateEvents();
+                        _updateDayEvents();
+                        
+                        print('DAY EVENTS');
+                        print(_dayEvents);
+                        print('LOADED EVENTS');
+                        print(_loadedEvents);
 
                         if (_dayEvents.isNotEmpty) {
                           _populateBuildList();
@@ -188,12 +188,11 @@ class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixi
   }
 
   // Takes the Arcs/Tasks in _loadedEvents and adds them to the _events List
-  void _updateEvents() {
+  void _updateDayEvents() {
+
+    print('ENTERING _updateEvents');
+
     _dayEvents.clear();
-    print('DAY EVENTS BEFORE');
-    print(_dayEvents);
-    print('\nLOADED EVENTS BEFORE');
-    print(_loadedEvents);
 
     _loadedEvents.forEach((String key, dynamic obj) {
       if (!_isInDayEvents(obj) &&
@@ -203,11 +202,6 @@ class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixi
         _dayEvents.addAll({key: obj});
       }
     });
-
-    print('\nDAY EVENTS AFTER');
-    print(_dayEvents);
-    print('\nLOADED EVENTS AFTER');
-    print(_loadedEvents);
 
     _visibleEvents = _events;
 
@@ -347,22 +341,6 @@ class _CalendarScreen extends State<CalendarScreen> with TickerProviderStateMixi
         _controller.forward(from: 0.0);
       },
       onVisibleDaysChanged: _onVisibleDaysChanged,
-    );
-  }
-
-  Widget _buildEventList() {
-    return ListView(
-      children: _selectedEvents.map((event) => Container(
-        decoration: BoxDecoration(
-          border: Border.all(width: 0.8),
-          borderRadius: BorderRadius.circular(12.0),
-        ),
-        margin: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 4.0),
-        child: ListTile(
-          title: Text(event.toString()),
-          onTap: () => print('$event tapped!'),
-        ),
-      )).toList(),
     );
   }
 }

--- a/client/src/arcplanner/test/test_arc.dart
+++ b/client/src/arcplanner/test/test_arc.dart
@@ -4,23 +4,23 @@
  * Provided AS IS. No warranties expressed or implied. Use at your own risk.
  */
 
-import '../lib//model/arc.dart';
-import '../lib//model/user.dart';
-import '../lib//model/task.dart';
-import '../lib//util/databaseHelper.dart';
-import 'package:test_api/test_api.dart';
+// import '../lib//model/arc.dart';
+// import '../lib//model/user.dart';
+// import '../lib//model/task.dart';
+// import '../lib//util/databaseHelper.dart';
+// import 'package:test_api/test_api.dart';
 
-void main() {
-  var db = new DatabaseHelper();
+// void main() {
+//   var db = new DatabaseHelper();
 
-  //Create test User and Arc for testing
-  User testUser = new User("test", "user", "testEmail@email.com");
-  db.insertUser(testUser);
-  Arc testArc = new Arc(testUser.uid, "test arc");
+//   //Create test User and Arc for testing
+//   User testUser = new User("test", "user", "testEmail@email.com");
+//   db.insertUser(testUser);
+//   Arc testArc = new Arc(testUser.uid, "test arc");
 
-  test('Task should be added', () {
-    testArc.addTask("testTitle1");
+//   test('Task should be added', () {
+//     testArc.addTask("testTitle1");
 
-    expect(testArc.tasks[0].title, "test arc");
-  });
-}
+//     expect(testArc.tasks[0].title, "test arc");
+//   });
+// }


### PR DESCRIPTION
This PR establishes the functionality of the Calendar View, as described in the SRS and UI document on the wiki. It allows users to scroll through a calendar and select days. If a selected day contains an Arc or a Task, it will be displayed in a scrollable list below the Calendar, using the Arc and Task tiles used throughout ArcPlanner. 

Known Issues:
- Icons showing the number of events on a day do not appear until the screen is interacted with, such as selecting a day. If anyone has any ideas on how to address this please let me know. 

Other:
- This PR incorporates a fix for the Home Screen that allows it to show tasks that are due on the current day
- This PR also adds a new helper file `tile.dart` which contains the implementation of the Arc and Task tiles. This file can be imported in the place of `arc_tile.dart` and `task_tile.dart` and also allows for the removal of the `Widget tile(dynamic, BuildContext)` function in each file that uses tiles.